### PR TITLE
Removed access to the asyncio event loop from synchronous function in Client.publish()

### DIFF
--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -192,8 +192,6 @@ class Client(MqttPackageHandler):
         return self._connection.unsubscribe(topic, **kwargs)
 
     def publish(self, message_or_topic, payload=None, qos=0, retain=False, **kwargs):
-        loop = asyncio.get_event_loop()
-
         if isinstance(message_or_topic, Message):
             message = message_or_topic
         else:


### PR DESCRIPTION
There has been a wrong reference to the asyncio event loop in the Client.publish() method.
Removed it, since the according line had no effect.

See #46