### PR TITLE
Properly cancel the '_resend_qos_messages' async task upon disconnection

### DIFF
--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -176,10 +176,10 @@ class Client(MqttPackageHandler):
 
     async def disconnect(self, reason_code=0, **properties):
         self.stop_reconnect()
+        self._resend_task.cancel()
         await self._disconnect(reason_code=reason_code, **properties)
 
     async def _disconnect(self, reason_code=0, **properties):
-        self._resend_task.cancel()
         if self._connection:
             self._connection.send_disconnect(reason_code=reason_code, **properties)
             await self._connection.close()


### PR DESCRIPTION
A simple disconnect/connect with the same client would create multiple tasks for this single coroutine, and closing the loop can raise lots of error messages:
```
2019-08-02 15:27:55,270  ERROR    [asyncio] Task was destroyed but it is pending!
task: <Task pending coro=<Client._resend_qos_messages() running at /home/guillaume/src/gmqtt/gmqtt/client.py:86> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f3fc0e14e10>()]>>
```