### PR TITLE
[WIP] Async/Await Prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ dist/
 # virtualenvs
 env/
 pyenv/
+.venv/
 
 # pytest
 .coverage
 .pytest_cache/
 htmlcov/
+.mypy_cache/

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -123,9 +123,7 @@ class Connect:
         receive_maximum: Optional[int] = None,
     ):
 
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self.loop = loop
+        self.loop = loop or asyncio.get_event_loop()
 
         client_args = {}
         if receive_maximum:

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -78,7 +78,7 @@ class MqttClientWrapper:
         async def __await_impl__(self):
             subscription = Subscription(on_unsubscribe=self._unsubscribe)
             self.client_wrapper._subscriptions[self.topic].add(subscription)
-            self.client_wrapper.client.subscribe(self.topic, self.qos)
+            self.client_wrapper.client.subscribe(self.topic, qos=self.qos)
 
             return subscription
 

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -1,0 +1,91 @@
+import asyncio
+from .client import Client, Message
+from typing import Optional, Tuple
+
+
+class MqttClientProtocol:
+    """
+    Wraps the normal client in the async/await API
+    """
+
+    def __init__(
+        self, inner_client: Client, loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
+
+        self.cbclient = inner_client
+        self.message_queue = asyncio.Queue()
+
+    async def publish(self, topic: str, message: Message, qos=0):
+        """Publish a message to the MQTT broker"""
+        self.cbclient.publish(topic, message, qos)
+
+    async def subscribe(self, topic: str, qos) -> Tuple[str, bytes]:
+        """Subscribe to a MQTT topic and wait for a single message."""
+
+        def _on_message(client, topic, payload, qos, properties):
+            self.message_queue.put_nowait((topic, payload))
+
+        self.cbclient.on_message = _on_message
+
+        self.cbclient.subscribe(topic, qos)
+        return await self.message_queue.get()
+
+
+class Connect:
+    """
+    An async context manager that provides a connected MQTT Client.
+    Responsible for setting up and tearing down the client.
+
+    >>> async with Connect('iot.eclipse.org') as client:
+    >>>     await client.publish('test/message', 'hello world', qos=1)
+    >>>     message = await client.subscribe('test/message')
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        broker_host: str,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        *args,
+        **kwargs
+    ):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
+
+        # cbclient: callback client.
+        self.cbclient = Client(client_id)
+        self.broker_host = broker_host
+        self._connect_future = self.loop.create_future()
+        self._disconnect_future = self.loop.create_future()
+
+    async def _connect(self, broker_host) -> MqttClientProtocol:
+        def _on_connect(client, flags, rc, properties):
+            self._connect_future.set_result(client)
+
+        self.cbclient.on_connect = _on_connect
+
+        await self.cbclient.connect(broker_host)
+        return await self._connect_future
+
+    async def _disconnect(self):
+        def _on_disconnect(client, packet, exc=None):
+            self._disconnect_future.set_result(packet)
+
+        self.cbclient.on_disconnect = _on_disconnect
+        await self.cbclient.disconnect()
+        return await self._disconnect_future
+
+    async def __aenter__(self) -> MqttClientProtocol:
+        cbclient = await self._connect(self.broker_host)
+        return MqttClientProtocol(cbclient, self.loop)
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self._disconnect()
+
+
+# Make context manager look like a function `connect`
+connect = Connect

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -117,8 +117,8 @@ class Connect:
 
     def __init__(
         self,
-        client_id: str,
         broker_host: str,
+        client_id: Optional[str] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         receive_maximum: Optional[int] = None,
     ):

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -15,6 +15,13 @@ class Subscription:
         # TODO: Hold off sending PUBACK for `message` until this point
         return message
 
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        while True:
+            return await self.receive()
+
     async def unsubscribe(self):
         await self._on_unsubscribe()
 

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -25,12 +25,13 @@ class MqttClientWrapper:
         """Publish a message to the MQTT topic"""
         self.client.publish(topic, message, qos)
 
-    async def subscribe(self, topic: str, qos: int) -> Tuple[str, bytes]:
+    async def subscribe(self, topic: str, qos: int) -> Tuple[str, Message]:
         """Subscribe to messages on the MQTT topic"""
 
         def _on_message(client, topic, payload, qos, properties):
-            # TODO: Handle recieved message when queue full
-            self.message_queue.put_nowait((topic, payload))
+            # TODO: Handle recieved message when queue full (drop a qos=0 packet)
+            message = Message(topic, payload, qos=qos, **properties)
+            self.message_queue.put_nowait((topic, message))
 
         self.client.on_message = _on_message
 

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -69,7 +69,7 @@ class Connect:
         self._disconnect_future = self.loop.create_future()
         self._receive_maximum = receive_maximum
 
-    async def _connect(self, broker_host) -> MqttClientProtocol:
+    async def _connect(self, broker_host) -> MqttClientWrapper:
         def _on_connect(client, flags, rc, properties):
             self._connect_future.set_result(client)
 
@@ -86,9 +86,9 @@ class Connect:
         await self.client.disconnect()
         return await self._disconnect_future
 
-    async def __aenter__(self) -> MqttClientProtocol:
+    async def __aenter__(self) -> MqttClientWrapper:
         client = await self._connect(self.broker_host)
-        return MqttClientProtocol(
+        return MqttClientWrapper(
             client, self.loop, recieve_maximum=self._receive_maximum
         )
 

--- a/gmqtt/aioclient.py
+++ b/gmqtt/aioclient.py
@@ -23,7 +23,7 @@ class MqttClientWrapper:
 
         self.client = inner_client
 
-        receive_maximum = receive_maximum or 65665
+        receive_maximum = receive_maximum or 65665  # FIXME: Sane default?
 
         self.subscription_manager = SubscriptionManager(receive_maximum)
         # self.message_queue = asyncio.Queue(maxsize=receive_maximum or 0)

--- a/gmqtt/message_queue.py
+++ b/gmqtt/message_queue.py
@@ -1,7 +1,79 @@
+import asyncio
+import enum
+import functools
+import collections
 
-from typing import Litteral
+# from .aioclient import Subscription
+from .client import Message
 
-DropPolicy = Litteral["oldest_first"]
+from typing import List, Tuple, Dict, Callable
+
+
+class TopicFilter:
+    def __init__(self, topic_filter: str):
+        self.levels = topic_filter.split("/")
+        TopicFilter.validate_topic(self.levels)
+
+    @staticmethod
+    def validate_topic(filter_levels: List[str]):
+        if filter_levels[-1][-1] == "#":
+            if len(filter_levels[-1]) > 1:
+                raise ValueError("Multi-level wildcard must be on its own level")
+
+        if "#" in "".join(filter_levels[:-1]):
+            raise ValueError(
+                "Multi-level wildcard must be at the end of the topic filter"
+            )
+
+        for level in filter_levels:
+            if len(level) > 1:
+                if "+" in level:
+                    raise ValueError("Single-level wildcard (+) only allowed by itself")
+
+    def match(self, topic: str) -> bool:
+        topic_levels = topic.split("/")
+
+        for filter_level, topic_level in zip(self.levels, topic_levels):
+            if filter_level == "+":
+                continue
+            elif filter_level == "#":
+                return True
+            else:
+                if filter_level != topic_level:
+                    return False
+        return True
+
+    def __hash__(self):
+        return hash("/".join(self.levels))
+
+
+class Subscription:
+    def __init__(self, message_queue: asyncio.Queue, on_unsubscribe: Callable):
+        self._incoming_messages = message_queue
+        self._on_unsubscribe = on_unsubscribe
+
+    async def recv(self):
+        """Receive the next message published to this subscription"""
+        message = await self._incoming_messages.get()
+        # TODO: Hold off sending PUBACK for `message` until this point
+        return message
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self.receive()
+
+    async def unsubscribe(self):
+        await self._on_unsubscribe()
+
+    def _add_message(self, message: Message):
+        self._incoming_messages.put_nowait(message)
+
+
+class DropPolicy(enum.Enum):
+    OLDEST_FIRST = enum.auto()
+
 
 class SubscriptionManager:
     """
@@ -12,44 +84,42 @@ class SubscriptionManager:
       - Routing messages to subscriptions based on topic (possibily with wildcards)
     """
 
-
-    def __init__(self, recieve_maximum: int, drop_policy: DropPolicy="oldest_first"):
-        self.subs = collections.defaultdict(list)
-
+    def __init__(
+        self, receive_maximum: int, drop_policy: DropPolicy = DropPolicy.OLDEST_FIRST
+    ):
         self.receive_maximum = receive_maximum
+        self.drop_policy = drop_policy
+        self.subs: Dict[TopicFilter, List["asyncio.Queue"]] = collections.defaultdict(
+            list
+        )
         self.size = 0
 
-        self.drop_policy = drop_policy
+    async def add_subscription(self, topic_filter_str: str) -> Subscription:
+        topic_filter = TopicFilter(topic_filter_str)
 
+        subscribed_messages = asyncio.Queue(self.receive_maximum)
+        sub_id = (topic_filter, len(self.subs[topic_filter]))
+        self.subs[topic_filter].append(subscribed_messages)
 
-    async def add_subscription(topic: str) -> Subscription:
-        subscribed_messages = asyncio.Queue(receive_maximum)
-        self.subs[subscription_topic].append(subscribed_messages)
+        return Subscription(
+            message_queue=subscribed_messages,
+            on_unsubscribe=functools.partial(self.remove_subscription, sub_id=sub_id),
+        )
 
-        # TODO: see `unsubscribe`
-        return Subscription(message_queue=subscribed_messages, 
-                on_unsubscribe=functools.partial(self.unsubscribe, topic=topic))
+    async def remove_subscription(self, sub_id: Tuple[TopicFilter, int]):
+        topic_filter, idx = sub_id
 
-    async def remove_subscription(self, topic: str):
-        # TODO: Need to track invidual subscribers, so if multiple subs are on a topic,
-        # the correct one is unsubscribed.
-        pass
+        # TODO: Unsubscribe on underlying client
+        # Note: Don't remove so indexes are preserved
+        self.subs[topic_filter][idx] = None
 
-
-    async def on_message(self, message):
-
-        # check self.size
-
+    def on_message(self, message: Message):
+        # TODO: check self.size
 
         # if over, attempt to drop qos=0 packet using `drop_policy`
 
         # if under, add to appropiate queues:
         for subscription_topic in self.subs:
-            if match(subscription_topic, message.topic):
+            if subscription_topic.match(message.topic):
                 for subscription in self.subs[subscription_topic]:
-                    subscription.on_message(
-            if message.
-
-
-
-
+                    subscription.put_nowait(message)

--- a/gmqtt/message_queue.py
+++ b/gmqtt/message_queue.py
@@ -1,0 +1,55 @@
+
+from typing import Litteral
+
+DropPolicy = Litteral["oldest_first"]
+
+class SubscriptionManager:
+    """
+    Manages incoming messages and the downstream subscription objects.
+
+    Handles:
+      - Maximum Queue size and message drop policy
+      - Routing messages to subscriptions based on topic (possibily with wildcards)
+    """
+
+
+    def __init__(self, recieve_maximum: int, drop_policy: DropPolicy="oldest_first"):
+        self.subs = collections.defaultdict(list)
+
+        self.receive_maximum = receive_maximum
+        self.size = 0
+
+        self.drop_policy = drop_policy
+
+
+    async def add_subscription(topic: str) -> Subscription:
+        subscribed_messages = asyncio.Queue(receive_maximum)
+        self.subs[subscription_topic].append(subscribed_messages)
+
+        # TODO: see `unsubscribe`
+        return Subscription(message_queue=subscribed_messages, 
+                on_unsubscribe=functools.partial(self.unsubscribe, topic=topic))
+
+    async def remove_subscription(self, topic: str):
+        # TODO: Need to track invidual subscribers, so if multiple subs are on a topic,
+        # the correct one is unsubscribed.
+        pass
+
+
+    async def on_message(self, message):
+
+        # check self.size
+
+
+        # if over, attempt to drop qos=0 packet using `drop_policy`
+
+        # if under, add to appropiate queues:
+        for subscription_topic in self.subs:
+            if match(subscription_topic, message.topic):
+                for subscription in self.subs[subscription_topic]:
+                    subscription.on_message(
+            if message.
+
+
+
+

--- a/gmqtt/message_queue.py
+++ b/gmqtt/message_queue.py
@@ -62,7 +62,7 @@ class Subscription:
         return self
 
     async def __anext__(self):
-        return await self.receive()
+        return await self.recv()
 
     async def unsubscribe(self):
         await self._on_unsubscribe()

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -7,6 +7,7 @@ from gmqtt.message_queue import TopicFilter
 # TODO: Fixtures
 # Mock client
 
+
 @pytest.mark.asyncio
 async def test_plain_subscription():
     sm = message_queue.SubscriptionManager(999)
@@ -45,11 +46,12 @@ def test_match_topic_filter_multilevel_wildcard():
     assert tf.match("topic/")
     assert tf.match("topic")
 
+
 def test_invalid_multilevel_wildcard():
 
     with pytest.raises(ValueError) as exc:
         TopicFilter("sport/tennis/#/ranking")
-    
+
     with pytest.raises(ValueError):
         TopicFilter("#/tailing")
 

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -1,0 +1,57 @@
+import pytest
+
+import gmqtt
+from gmqtt import aioclient, message_queue
+from gmqtt.message_queue import TopicFilter
+
+# TODO: Fixtures
+# Mock client
+
+@pytest.mark.asyncio
+async def test_plain_subscription():
+    sm = message_queue.SubscriptionManager(999)
+    sub = await sm.add_subscription("topic/TEST")
+
+    message = gmqtt.Message(topic="topic/TEST", payload="payload")
+    sm.on_message(message)
+
+    received = await sub.recv()
+    assert received.topic == "topic/TEST"
+
+
+@pytest.mark.asyncio
+async def test_wildcard_subscription():
+    sm = message_queue.SubscriptionManager(999)
+    sub = await sm.add_subscription("topic/+")
+
+    message = gmqtt.Message(topic="topic/TEST", payload="payload")
+    sm.on_message(message)
+
+    received = await sub.recv()
+    assert received.topic == "topic/TEST"
+
+
+def test_match_topic_filter():
+    tf = TopicFilter("topic/TEST")
+    assert tf.match("topic/TEST")
+    assert tf.match("topic/FOO") == False
+
+
+def test_match_topic_filter_multilevel_wildcard():
+    tf = TopicFilter("topic/#")
+
+    assert tf.match("topic/TEST/1")
+    assert tf.match("topic/1")
+    assert tf.match("topic/")
+    assert tf.match("topic")
+
+def test_invalid_multilevel_wildcard():
+
+    with pytest.raises(ValueError) as exc:
+        TopicFilter("sport/tennis/#/ranking")
+    
+    with pytest.raises(ValueError):
+        TopicFilter("#/tailing")
+
+    with pytest.raises(ValueError):
+        TopicFilter("sport/tennis#")

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -1,8 +1,11 @@
 import pytest
+from unittest.mock import MagicMock
 
 import gmqtt
 from gmqtt import aioclient, message_queue
 from gmqtt.message_queue import TopicFilter
+from gmqtt.aioclient import MqttClientWrapper
+from gmqtt.client import Message
 
 # TODO: Fixtures
 # Mock client
@@ -57,3 +60,32 @@ def test_invalid_multilevel_wildcard():
 
     with pytest.raises(ValueError):
         TopicFilter("sport/tennis#")
+
+
+@pytest.fixture
+def client():
+    mock_inner = MagicMock()
+    mock_inner.subscribe.return_value = None
+    mock_inner.on_message = None
+
+    wrapper_client = MqttClientWrapper(mock_inner)
+
+    return wrapper_client, mock_inner
+
+@pytest.mark.asyncio
+async def test_multiple_subs_duplicate_messages(client):
+    client, mocked_inner = client
+
+    sub1 = await client.subscribe("test/test")
+    sub2 = await client.subscribe("test/test")
+
+    message = Message(topic="test/test", payload="payload")
+    mocked_inner.on_message(client=mocked_inner, topic=message.topic, payload=message.payload, qos=message.qos, properties={})
+
+    msg1 = await sub1.recv()
+    msg2 = await sub2.recv()
+
+    assert msg1.topic == "test/test"
+    assert msg2.topic == "test/test"
+    assert msg1.payload == b"payload"
+    assert msg2.payload == b"payload"


### PR DESCRIPTION
*Work in progress - Don't merge yet!*

This PR presents and alternative API that makes full use of Python's async/await feature like other well-known python async libraries such as websockets and aiohttp. The client connection is handled by an async context manager, and event handling is achieved with the `await` keyword instead of callback functions:
```py
async with gmqtt.connect('iot.eclipse.org') as client:
    await client.publish('test/message', 'hello world', qos=1)
    message = await client.subscribe('test/message')
```
### Converting callbacks to `await`-ables
Callbacks can be converted to awaitable objects, which simplifies the user's code significantly:
##### Before
```py
def on_message(client, topic, payload, qos, properties):
    print('RECV MSG:', payload)

client.on_message = on_message
client.subscribe('TEST/#', qos=0)
```
##### After
```py
message = await client.subscribe('TEST/#', qos=0)
print('RECV MSG:', message.payload)
```
I also spotted a few areas in the codebase that makes heavy use callbacks that can be simplified using this method.

### How
The various callback functions are made awaitable with a `asyncio.Future` object. This is how the `on_connect` callback can be adapted
```py
async def connect(self, broker_host) -> MqttClientProtocol:
    future = self.loop.create_future()

    def _on_connect(client, flags, rc, properties):
        future.set_result(client)
    self.client.on_connect = _on_connect

    await self.client.connect(broker_host)
    return await future
```
### Progress

- [x] ~multiple threading / possible concurrency errors (`Future` isn't threadsafe)~
- [x] subscriptions are long living, but treated as returning a single message
- [x] Routing messages to subscriptions using their topic filter
- [ ] any other functions in the API. Currently only have `publish` and `subscribe`
- [ ] Errors and Exceptions
- [x] How the API relates to the callback API; Should this be a wrapper or a replacement? *Wrapper*
- [ ] `gmqtt.connect` Arguments: Encryption, Authentication, Reconnection
- [ ] Decide on one of the three flow-control options, or something else I haven't considered
- [ ] Add unit tests that properly test the new API.
- [ ] Docstrings for public classes and functions
- [ ] Use API as the example in the Readme?