### PR TITLE
feature: close connection when lost heartbeat

### DIFF
--- a/gmqtt/mqtt/connection.py
+++ b/gmqtt/mqtt/connection.py
@@ -1,9 +1,10 @@
 import asyncio
-
+import logging
 import time
 
 from .protocol import MQTTProtocol
 
+logger = logging.getLogger(__name__)
 
 class MQTTConnection(object):
     def __init__(self, transport: asyncio.Transport, protocol: MQTTProtocol, clean_session: bool, keepalive: int):
@@ -29,11 +30,18 @@ class MQTTConnection(object):
     def _keep_connection(self):
         if self.is_closing():
             return
+
+        if time.monotonic() - self._last_data_in >= 2 * self._keepalive:
+            logger.warning("[LOST HEARTBEAT FOR %s SECONDS, GOING TO CLOSE CONNECTION]", 2 * self._keepalive)
+            asyncio.ensure_future(self.close())
+            return
+
         if time.monotonic() - self._last_data_in >= self._keepalive:
             self._send_ping_request()
         self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive, self._keep_connection)
 
     def put_package(self, pkg):
+        self._last_data_in = time.monotonic()
         self._handler(*pkg)
 
     def send_package(self, package):


### PR DESCRIPTION
 Since network is unreliable, it's necessary to handle connection lost situation. The variable `self._last_data_in` in `connection.py` can be used to detect network state, if client doesn't receive any message from server in two heartbeat interval, clinet should call connection close  and start reconnect. 