### PR TITLE
Remove double check for keepalive

### DIFF
--- a/gmqtt/mqtt/connection.py
+++ b/gmqtt/mqtt/connection.py
@@ -19,7 +19,7 @@ class MQTTConnection(object):
         self._last_data_in = time.monotonic()
         self._last_data_out = time.monotonic()
 
-        self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive, self._keep_connection)
+        self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive / 2, self._keep_connection)
 
     @classmethod
     async def create_connection(cls, host, port, ssl, clean_session, keepalive, loop=None):
@@ -36,9 +36,9 @@ class MQTTConnection(object):
             asyncio.ensure_future(self.close())
             return
 
-        if time.monotonic() - self._last_data_in >= self._keepalive:
+        if time.monotonic() - self._last_data_in >= 0.8 * self._keepalive:
             self._send_ping_request()
-        self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive, self._keep_connection)
+        self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive / 2, self._keep_connection)
 
     def put_package(self, pkg):
         self._last_data_in = time.monotonic()


### PR DESCRIPTION
(at least on MacOS) the `call_later`-target is executed some milliseconds before the set timeout and therefore the ping will not be sent in a valid time for the broker.

Explanation:
For example: if `keepalive` is set to 2 seconds timeout, the call will eventually be made after 1.91(+-) seconds. Thus, the first call comes in after 1.91 seconds and the comparison `if time.monotonic() - self._last_data_in >= self._keepalive` will evaluate to false. The second call will be made after 3.92 seconds - but its already too late to send the ping to the broker then, because the maximum tolerance on broker-side is 1.5 * `keepalive`.

As the timeout for `call_later` is already equal to `keepalive`, we can simply remove the double check inside the `_keep_connection` to have everything worky.