### PR TITLE
At https://github.com/sabuhish/fastapi-mqtt/issues/22 RuntimeError ra…

### DIFF
--- a/gmqtt/storage.py
+++ b/gmqtt/storage.py
@@ -9,6 +9,12 @@ class BasePersistentStorage(object):
         raise NotImplementedError
 
     def push_message_nowait(self, mid, raw_package) -> asyncio.Future:
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError as err:
+            if "There is no current event loop in thread" in str(err): 
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)   
         return asyncio.ensure_future(self.push_message(mid, raw_package))
 
     async def pop_message(self) -> Tuple[int, bytes]:


### PR DESCRIPTION
At https://github.com/sabuhish/fastapi-mqtt/issues/22 RuntimeError raised, it is because setting QoS 1 or 2 on publish method, Error occurs in ThreadPoolExecutor, does not find running event loop."