### PR TITLE
fixed server_keep_alive

### DIFF
--- a/gmqtt/mqtt/handler.py
+++ b/gmqtt/mqtt/handler.py
@@ -253,7 +253,7 @@ class MqttPackageHandler(EventCallback):
     def _update_keepalive_if_needed(self):
         if not self._connack_properties.get('server_keep_alive'):
             return
-        self._keepalive = self._connack_properties['server_keep_alive']
+        self._keepalive = self._connack_properties['server_keep_alive'][0]
         self._connection.keepalive = self._keepalive
 
     def _handle_connack_packet(self, cmd, packet):


### PR DESCRIPTION
When a server such as mochi MQTT sends a `server_keep_alive` property on CONNACK the handler would fail at "connection.py", line 108, in keepalive, trying to divide a list.
example output:
```
ERROR:gmqtt.mqtt.handler:[ERROR HANDLE PKG]
Traceback (most recent call last):
  File "/home/*********/handler.py", line 383, in __call__
    result = self._handle_packet(cmd, packet)
  File "/home/*********/handler.py", line 214, in _handle_packet
    handler(cmd, packet)
  File "/home/*********/handler.py", line 289, in _handle_connack_packet
    self._update_keepalive_if_needed()
  File "/home/*********/handler.py", line 257, in _update_keepalive_if_needed
    self._connection.keepalive = self._keepalive
  File "/home/*********/connection.py", line 108, in keepalive
    self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive / 2, self._keep_connection)
TypeError: unsupported operand type(s) for /: 'list' and 'int'
```