### PR TITLE
Properly handle already encoded topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 gmqtt.egg-info
 dist/
-
+build/
 # virtualenvs
 env/
 venv/

--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -15,7 +15,7 @@ from .storage import HeapPersistentStorage
 
 class Message:
     def __init__(self, topic, payload, qos=0, retain=False, **kwargs):
-        self.topic = topic.encode('utf-8', errors='replace') if isinstance(topic, str) else str
+        self.topic = topic.encode('utf-8', errors='replace') if isinstance(topic, str) else topic
         self.qos = qos
         self.retain = retain
         self.dup = False


### PR DESCRIPTION
client.py has a logc bug. When topic is not a string, it uses the 'class str' as the topic instead of its representation