### PR TITLE
fix: re-subscribe after re-connect

### DIFF
--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -273,6 +273,8 @@ class Client(MqttPackageHandler, SubscriptionsHandler):
             return
         await self._connection.auth(self._client_id, self._username, self._password,
                                     will_message=self._will_message, **self._connect_properties)
+        if self.subscriptions:
+            self._connection.subscribe(self.subscriptions)
 
     async def disconnect(self, reason_code=0, **properties):
         self._is_active = False


### PR DESCRIPTION
Closes #124 .

The solution was tested with a test suite and manually with ActiveMQ (MQTT3.1) as this was the place where I encountered the problem.