### PR TITLE
Multiple logic fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,6 +4,7 @@
 name: Python package
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,24 +16,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
-    - name: Test with pytest
-      env:
-        TOKEN: ${{ secrets.TOKEN }}
-      run: |
-        pytest --cov=gmqtt
-    - name: Code coverage
-      run: |
-        codecov
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
+      - name: Test with pytest
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          pytest --cov=gmqtt
+      - name: Code coverage
+        run: |
+          codecov

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.pyc
 *.pyo
 .idea
+.env
 gmqtt.egg-info
 dist/
 build/
+
 # virtualenvs
 env/
 venv/
@@ -13,3 +15,6 @@ pyenv/
 .coverage
 .pytest_cache/
 htmlcov/
+
+# agents
+CLAUDE.md

--- a/gmqtt/__init__.py
+++ b/gmqtt/__init__.py
@@ -1,17 +1,19 @@
 import datetime
 
-from .client import Client, Message, Subscription
+from .client import Client, Message
+from .subscription import Subscription
 from .mqtt import constants
 from .mqtt.protocol import BaseMQTTProtocol
 from .mqtt.handler import MQTTConnectError
 
 __author__ = "Mikhail Turchunovich"
-__email__ = 'mitu@gurtam.com'
+__email__ = 'dyez@gurtam.team'
 __copyright__ = ("Copyright 2013-%d, Gurtam; " % datetime.datetime.now().year,)
 
 __credits__ = [
     "Mikhail Turchunovich",
-    "Elena Shylko"
+    "Elena Shylko",
+    "Dmitry Yezepchik"
 ]
 __version__ = "0.7.0"
 

--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -1,22 +1,22 @@
 import asyncio
 import json
-
 import logging
 import uuid
-from copy import copy
-from typing import Union, Sequence
+from functools import partial
+from typing import Sequence, Union
 
-from .mqtt.protocol import MQTTProtocol
 from .mqtt.connection import MQTTConnection
+from .mqtt.constants import UNLIMITED_RECONNECTS, MQTTv50
 from .mqtt.handler import MqttPackageHandler
-from .mqtt.constants import MQTTv50, UNLIMITED_RECONNECTS
-
-from .storage import HeapPersistentStorage
+from .mqtt.utils import ConnectionState
+from .storage import PersistentStorage
 
 
 class Message:
     def __init__(self, topic, payload, qos=0, retain=False, **kwargs):
-        self.topic = topic.encode('utf-8', errors='replace') if isinstance(topic, str) else topic
+        self.topic = (
+            topic.encode("utf-8", errors="replace") if isinstance(topic, str) else topic
+        )
         self.qos = qos
         self.retain = retain
         self.dup = False
@@ -26,23 +26,30 @@ class Message:
             payload = json.dumps(payload, ensure_ascii=False)
 
         if isinstance(payload, (int, float)):
-            self.payload = str(payload).encode('ascii')
+            self.payload = str(payload).encode("ascii")
         elif isinstance(payload, str):
-            self.payload = payload.encode('utf-8', errors='replace')
+            self.payload = payload.encode("utf-8", errors="replace")
         elif payload is None:
-            self.payload = b''
+            self.payload = b""
         else:
             self.payload = payload
 
         self.payload_size = len(self.payload)
 
         if self.payload_size > 268435455:
-            raise ValueError('Payload too large.')
+            raise ValueError("Payload too large.")
 
 
 class Subscription:
-    def __init__(self, topic, qos=0, no_local=False, retain_as_published=False, retain_handling_options=0,
-                 subscription_identifier=None):
+    def __init__(
+        self,
+        topic,
+        qos=0,
+        no_local=False,
+        retain_as_published=False,
+        retain_handling_options=0,
+        subscription_identifier=None,
+    ):
         self.topic = topic
         self.qos = qos
         self.no_local = no_local
@@ -56,15 +63,24 @@ class Subscription:
         self.subscription_identifier = subscription_identifier
 
 
-class SubscriptionsHandler:
+class SubscriptionsHandlerMixin:
     def __init__(self):
         self.subscriptions = []
+        # defined by a main class
+        self._connection = None
 
     def update_subscriptions_with_subscription_or_topic(
-            self, subscription_or_topic, qos, no_local, retain_as_published, retain_handling_options, kwargs):
+        self,
+        subscription_or_topic,
+        qos,
+        no_local,
+        retain_as_published,
+        retain_handling_options,
+        kwargs,
+    ):
 
         sentinel = object()
-        subscription_identifier = kwargs.get('subscription_identifier', sentinel)
+        subscription_identifier = kwargs.get("subscription_identifier", sentinel)
 
         if isinstance(subscription_or_topic, Subscription):
 
@@ -84,12 +100,20 @@ class SubscriptionsHandler:
             if subscription_identifier is sentinel:
                 subscription_identifier = None
 
-            subscriptions = [Subscription(subscription_or_topic, qos=qos, no_local=no_local,
-                                          retain_as_published=retain_as_published,
-                                          retain_handling_options=retain_handling_options,
-                                          subscription_identifier=subscription_identifier)]
+            subscriptions = [
+                Subscription(
+                    subscription_or_topic,
+                    qos=qos,
+                    no_local=no_local,
+                    retain_as_published=retain_as_published,
+                    retain_handling_options=retain_handling_options,
+                    subscription_identifier=subscription_identifier,
+                )
+            ]
         else:
-            raise ValueError('Bad subscription: must be string or Subscription or list of Subscriptions')
+            raise ValueError(
+                "Bad subscription: must be string or Subscription or list of Subscriptions"
+            )
         self.subscriptions.extend(subscriptions)
         return subscriptions
 
@@ -99,23 +123,36 @@ class SubscriptionsHandler:
         else:
             self.subscriptions = [s for s in self.subscriptions if s.topic not in topic]
 
-    def subscribe(self, subscription_or_topic: Union[str, Subscription, Sequence[Subscription]],
-                  qos=0, no_local=False, retain_as_published=False, retain_handling_options=0, **kwargs):
+    def subscribe(
+        self,
+        subscription_or_topic: Union[str, Subscription, Sequence[Subscription]],
+        qos=0,
+        no_local=False,
+        retain_as_published=False,
+        retain_handling_options=0,
+        **kwargs
+    ):
 
         # Warn: if you will pass a few subscriptions objects, and each will be have different
         # subscription identifier - the only first will be used as identifier
         # if only you will not pass the identifier in kwargs
 
         subscriptions = self.update_subscriptions_with_subscription_or_topic(
-            subscription_or_topic, qos, no_local, retain_as_published, retain_handling_options, kwargs)
+            subscription_or_topic,
+            qos,
+            no_local,
+            retain_as_published,
+            retain_handling_options,
+            kwargs,
+        )
         return self._connection.subscribe(subscriptions, **kwargs)
 
     def resubscribe(self, subscription: Subscription, **kwargs):
         # send subscribe packet for subscription,that's already in client's subscription list
-        if 'subscription_identifier' in kwargs:
-            subscription.subscription_identifier = kwargs['subscription_identifier']
+        if "subscription_identifier" in kwargs:
+            subscription.subscription_identifier = kwargs["subscription_identifier"]
         elif subscription.subscription_identifier is not None:
-            kwargs['subscription_identifier'] = subscription.subscription_identifier
+            kwargs["subscription_identifier"] = subscription.subscription_identifier
         return self._connection.subscribe([subscription], **kwargs)
 
     def unsubscribe(self, topic: Union[str, Sequence[str]], **kwargs):
@@ -123,14 +160,62 @@ class SubscriptionsHandler:
         return self._connection.unsubscribe(topic, **kwargs)
 
 
-class Client(MqttPackageHandler, SubscriptionsHandler):
-    def __init__(self, client_id, clean_session=True, optimistic_acknowledgement=True,
-                 will_message=None, logger=None, **kwargs):
-        super(Client, self).__init__(optimistic_acknowledgement=optimistic_acknowledgement, logger=logger)
+class Client(SubscriptionsHandlerMixin):
+    def __init__(
+        self,
+        client_id,
+        clean_session=True,
+        optimistic_acknowledgement=True,
+        will_message=None,
+        persistent_storage=None,
+        logger=None,
+        **kwargs
+    ):
+
+        super().__init__()
+
         self._client_id = client_id or uuid.uuid4().hex
+        self._connection_state = ConnectionState()
+
+        # TOD0: Move to a dedicated init/conn properties validator
+        # MQTT 5.0 §3.1.2.11.2 — Session Expiry Interval is a Four Byte Integer (seconds).
+        # 0 (or absent) = session ends when the Network Connection is closed.
+        # 0xFFFFFFFF = session never expires.
+        # The server MAY override the requested value in CONNACK (§3.2.2.3.2); read it back
+        # via the `session_expiry_interval` property after connect.
+        session_expiry_interval = kwargs.get("session_expiry_interval")
+        if session_expiry_interval is not None:
+            if not isinstance(session_expiry_interval, int) or isinstance(session_expiry_interval, bool):
+                raise TypeError("session_expiry_interval must be an int (seconds, 0..0xFFFFFFFF)")
+            if not 0 <= session_expiry_interval <= 0xFFFFFFFF:
+                raise ValueError(
+                    "session_expiry_interval must be in [0, 0xFFFFFFFF]; "
+                    "0 = end on disconnect, 0xFFFFFFFF = never expires"
+                )
+
+        self._connect_properties = kwargs
+
+        self._connack_received = asyncio.Event()
+        self._package_handler = MqttPackageHandler(
+            connack_event=self._connack_received,
+            connection_state=self._connection_state,
+            reconnect_callback=self.reconnect,
+            disconnect_callback=self.disconnect,
+            resend_qos_callback=self._resend_qos_messages,
+            clear_qos_callback=self._clear_resend_qos_queue,
+            remove_message_callback=self._remove_message_from_queue,
+            send_command_with_mid_callback=self._send_command_with_mid,
+            connect_properties=self._connect_properties,
+            subscriptions_getter=lambda: self.subscriptions,
+            optimistic_acknowledgement=optimistic_acknowledgement,
+            logger=logger,
+        )
 
         # in MQTT 5.0 this is clean start flag
         self._clean_session = clean_session
+
+        # this flag should be True after connect and False when disconnect was called
+        self._is_active = False
 
         self._connection = None
         self._keepalive = 60
@@ -142,68 +227,192 @@ class Client(MqttPackageHandler, SubscriptionsHandler):
         self._port = None
         self._ssl = None
 
-        self._connect_properties = kwargs
-        self._connack_properties = {}
-
         self._will_message = will_message
 
-        # TODO: this constant may be moved to config
-        self._persistent_storage = kwargs.pop('persistent_storage', HeapPersistentStorage())
+        self._persistent_storage = persistent_storage or PersistentStorage()
 
-        self._topic_alias_maximum = kwargs.get('topic_alias_maximum', 0)
+        self._topic_alias_maximum = kwargs.get("topic_alias_maximum", 0)
 
         self._logger = logger or logging.getLogger(__name__)
 
-    def get_subscription_by_identifier(self, subscription_identifier):
-        return next((sub for sub in self.subscriptions if sub.subscription_identifier == subscription_identifier), None)
+    @property
+    def session_expiry_interval(self):
+        """Effective Session Expiry Interval (seconds), per MQTT 5.0 §3.1.2.11.2.
 
-    def get_subscriptions_by_mid(self, mid):
-        return [sub for sub in self.subscriptions if sub.mid == mid]
-
-    def _remove_message_from_query(self, mid):
-        self._logger.debug('[REMOVE MESSAGE] %s', mid)
-        asyncio.ensure_future(
-            self._persistent_storage.remove_message_by_mid(mid)
+        Returns the value advertised by the server in CONNACK if present
+        (§3.2.2.3.2 — the server's value overrides the client's request),
+        otherwise the value the client requested, otherwise 0 (spec default:
+        session ends when the Network Connection is closed).
+        A value of 0xFFFFFFFF means the session never expires.
+        """
+        server_value = self._package_handler._connack_properties.get(
+            "session_expiry_interval"
         )
+        if server_value is not None:
+            # _parse_properties always stores values as lists via defaultdict(list).
+            return server_value[0] if isinstance(server_value, list) else server_value
+
+        return self._connect_properties.get("session_expiry_interval", 0)
+
+    def get_subscription_by_identifier(self, subscription_identifier):
+        return next(
+            (
+                sub
+                for sub in self.subscriptions
+                if sub.subscription_identifier == subscription_identifier
+            ),
+            None,
+        )
+
+    def _handle_exception_in_future(self, future, msg=None):
+        """Done-callback for fire-and-forget futures.
+
+        msg: string to be added to the log message with the exception itself
+        """
+        exc = future.exception()
+        log_string = "[Client]: %s"
+        if msg:
+            log_string = "[Client] " + msg + ": %s"
+
+        if exc:
+            self._logger.warning(log_string, exc)
+
+    # ------------------------------------------------------------------
+    # Event callback delegation — properties live on _package_handler;
+    # expose them on Client so callers can do client.on_message = fn.
+    # ------------------------------------------------------------------
+
+    @property
+    def on_connect(self):
+        return self._package_handler.on_connect
+
+    @on_connect.setter
+    def on_connect(self, cb):
+        """
+        Called when the broker accepts the connection
+
+        Signature: on_connect(client, flags, rc, properties)
+        """
+        self._package_handler.on_connect = partial(cb, self)
+
+    @property
+    def on_message(self):
+        return self._package_handler.on_message
+
+    @on_message.setter
+    def on_message(self, cb):
+        """
+        Called for every inbound packet
+
+        Signature: on_message(client, topic, payload, qos, properties)
+        """
+        self._package_handler.on_message = partial(cb, self)
+
+    @property
+    def on_disconnect(self):
+        return self._package_handler.on_disconnect
+
+    @on_disconnect.setter
+    def on_disconnect(self, cb):
+        """
+        Called when the connection is lost or the broker disconnects
+
+        Signature: on_disconnect(client, packet, exc)
+        """
+        self._package_handler.on_disconnect = partial(cb, self)
+
+    @property
+    def on_subscribe(self):
+        return self._package_handler.on_subscribe
+
+    @on_subscribe.setter
+    def on_subscribe(self, cb):
+        """
+        Called when a subscription request is received
+
+        Signature: on_subscribe(client, mid, qos, properties)
+        """
+        self._package_handler.on_subscribe = partial(cb, self)
+
+    @property
+    def on_unsubscribe(self):
+        return self._package_handler.on_unsubscribe
+
+    @on_unsubscribe.setter
+    def on_unsubscribe(self, cb):
+        """
+        Called when an unsubscription request is received
+
+        Signature: on_unsubscribe(client, mid, qos)
+        """
+        self._package_handler.on_unsubscribe = partial(cb, self)
+
+    def set_config(self, config: dict):
+        self._connection_state.config.update(config)
+
+    def stop_reconnect(self):
+        self._package_handler.stop_reconnect()
+
+    @property
+    def reconnect_delay(self):
+        return self._package_handler.reconnect_delay
+
+    @reconnect_delay.setter
+    def reconnect_delay(self, value):
+        self._package_handler.reconnect_delay = value
+
+    @property
+    def reconnect_retries(self):
+        return self._package_handler.reconnect_retries
+
+    @reconnect_retries.setter
+    def reconnect_retries(self, value):
+        self._package_handler.reconnect_retries = value
+
+    def _remove_message_from_queue(self, mid):
+        self._logger.debug("[Client] remove message. mid: %s", mid)
+        future = asyncio.ensure_future(self._persistent_storage.remove_message_by_mid(mid))
+        future.add_done_callback(partial(self._handle_exception_in_future, msg="remove message"))
 
     @property
     def is_connected(self):
         # tells if connection is alive and CONNACK was received
-        return self._connected.is_set() and not self._connection.is_closing()
+        return self._connack_received.is_set() and not self._connection.is_closing()
 
     async def _resend_qos_messages(self):
-        await self._connected.wait()
+        await self._connack_received.wait()
 
         if await self._persistent_storage.is_empty:
-            self._logger.debug('[QoS query IS EMPTY]')
+            self._logger.debug("[Client] QoS queue is empty, nothing to replay")
             return
         elif self._connection.is_closing():
-            self._logger.debug('[Some msg need to resend] Transport is closing')
+            self._logger.warning(
+                "[Client] transport already closing, skipping replay of %s message(s) — "
+                "next reconnect will retry",
+                len(await self._persistent_storage.get_all()),
+            )
             return
         else:
-            msgs = copy(await self._persistent_storage.get_all())
-            self._logger.debug('[msgs need to resend] processing %s messages', len(msgs))
+            msgs = await self._persistent_storage.get_all()
+            self._logger.debug(
+                "[Client] replaying %s inflight message(s)", len(msgs)
+            )
 
             await self._persistent_storage.clear()
 
-            for msg in msgs:
-                (_, mid, package) = msg
-
+            for mid, package in msgs:
                 try:
                     self._connection.send_package(package)
                 except Exception as exc:
-                    self._logger.error('[ERROR WHILE RESENDING] mid: %s', mid, exc_info=exc)
+                    self._logger.error(
+                        "[Client] failed to resend mid=%s, kept in queue for next reconnect",
+                        mid, exc_info=exc
+                    )
 
-                await self._persistent_storage.push_message(mid, package)
+                self._persistent_storage.push_message(mid, package)
 
     async def _clear_resend_qos_queue(self):
         await self._persistent_storage.clear()
-
-
-    @property
-    def properties(self):
-        # merge two dictionaries from connect and connack packages
-        return {**self._connack_properties, **self._connect_properties}
 
     def set_auth_credentials(self, username, password=None):
         self._username = username.encode()
@@ -211,7 +420,9 @@ class Client(MqttPackageHandler, SubscriptionsHandler):
         if isinstance(self._password, str):
             self._password = password.encode()
 
-    async def connect(self, host, port=1883, ssl=False, keepalive=60, version=MQTTv50, raise_exc=True):
+    async def connect(
+        self, host, port=1883, ssl=False, keepalive=60, version=MQTTv50, raise_exc=True
+    ):
         # Init connection
         self._host = host
         self._port = port
@@ -219,68 +430,114 @@ class Client(MqttPackageHandler, SubscriptionsHandler):
         self._keepalive = keepalive
         self._is_active = True
 
-        MQTTProtocol.proto_ver = version
+        self._connection_state.protocol_version = version
 
         self._connection = await self._create_connection(
-            host, port=self._port, ssl=self._ssl, clean_session=self._clean_session, keepalive=keepalive)
+            host,
+            port=self._port,
+            ssl=self._ssl,
+            clean_session=self._clean_session,
+            keepalive=keepalive,
+        )
 
-        await self._connection.auth(self._client_id, self._username, self._password, will_message=self._will_message,
-                                    **self._connect_properties)
-        await self._connected.wait()
+        await self._connection.auth(
+            self._client_id,
+            self._username,
+            self._password,
+            will_message=self._will_message,
+            **self._connect_properties
+        )
+        await self._connack_received.wait()
 
         await self._persistent_storage.wait_empty()
 
-        if raise_exc and self._error:
-            raise self._error
+        if raise_exc and self._package_handler.has_error:
+            raise self._package_handler.propagate_error()
+
+    def _exit_reconnecting_state(self):
+        self._connection_state.reconnecting_now = False
 
     async def _create_connection(self, host, port, ssl, clean_session, keepalive):
-        # important for reconnects, make sure u know what u are doing if wanna change :(
+        # important for reconnects! Make sure u know what u're doing if you wanna change it :(
         self._exit_reconnecting_state()
-        self._clear_topics_aliases()
-        connection = await MQTTConnection.create_connection(host, port, ssl, clean_session, keepalive, logger=self._logger)
-        connection.set_handler(self)
+        self._package_handler.clear_topics_aliases()
+        connection = await MQTTConnection.create_connection(
+            host,
+            port,
+            ssl,
+            clean_session,
+            keepalive,
+            connection_state=self._connection_state,
+            package_handler=self._package_handler,
+            logger=self._logger,
+        )
         return connection
 
+    def _temporarily_stop_reconnect(self):
+        self._connection_state.reconnecting_now = True
+
     def _allow_reconnect(self):
-        if self._reconnecting_now or not self._is_active:
+        if self._connection_state.reconnecting_now or not self._is_active:
             return False
-        if self._config['reconnect_retries'] == UNLIMITED_RECONNECTS:
+        if self._connection_state.config["reconnect_retries"] == UNLIMITED_RECONNECTS:
             return True
-        if self.failed_connections <= self._config['reconnect_retries']:
+        if self._connection_state.failed_connections <= self._connection_state.config["reconnect_retries"]:
             return True
-        self._logger.error('[DISCONNECTED] max number of failed connection attempts achieved')
+        self._logger.error(
+            "[Client] max number of failed connection attempts achieved"
+        )
         return False
 
     async def reconnect(self, delay=False):
         if not self._allow_reconnect():
             return
+
         # stopping auto-reconnects during reconnect procedure is important, better do not touch :(
-        self._temporatily_stop_reconnect()
+        self._temporarily_stop_reconnect()
+
         try:
             await self._disconnect()
-        except:
-            self._logger.info('[RECONNECT] ignored error while disconnecting, trying to reconnect anyway')
+        except Exception:
+            self._logger.info(
+                "[Client] ignored error while disconnecting, trying to reconnect anyway"
+            )
+
         if delay:
-            await asyncio.sleep(self._config['reconnect_delay'])
+            await asyncio.sleep(self._connection_state.config["reconnect_delay"])
+
         try:
-            self._connection = await self._create_connection(self._host, self._port, ssl=self._ssl,
-                                                             clean_session=False, keepalive=self._keepalive)
+            self._connection = await self._create_connection(
+                self._host,
+                self._port,
+                ssl=self._ssl,
+                clean_session=False,
+                keepalive=self._keepalive,
+            )
         except OSError as exc:
-            self.failed_connections += 1
-            self._logger.warning("[CAN'T RECONNECT] %s", self.failed_connections)
+            self._connection_state.failed_connections += 1
+            self._logger.warning(
+                "[Client] failed to reconnect. Number of retries: %s. Reason: %s",
+                self._connection_state.failed_connections, exc
+            )
             asyncio.ensure_future(self.reconnect(delay=True))
             return
-        await self._connection.auth(self._client_id, self._username, self._password,
-                                    will_message=self._will_message, **self._connect_properties)
+
+        await self._connection.auth(
+            self._client_id,
+            self._username,
+            self._password,
+            will_message=self._will_message,
+            **self._connect_properties
+        )
 
     async def disconnect(self, reason_code=0, **properties):
         self._is_active = False
         await self._disconnect(reason_code=reason_code, **properties)
 
     async def _disconnect(self, reason_code=0, **properties):
-        self._clear_topics_aliases()
+        self._package_handler.clear_topics_aliases()
 
-        self._connected.clear()
+        self._connack_received.clear()
         if self._connection:
             self._connection.send_disconnect(reason_code=reason_code, **properties)
             await self._connection.close()
@@ -289,20 +546,17 @@ class Client(MqttPackageHandler, SubscriptionsHandler):
         if isinstance(message_or_topic, Message):
             message = message_or_topic
         else:
-            message = Message(message_or_topic, payload, qos=qos, retain=retain, **kwargs)
+            message = Message(
+                message_or_topic, payload, qos=qos, retain=retain, **kwargs
+            )
 
         mid, package = self._connection.publish(message)
 
         if qos > 0:
-            self._persistent_storage.push_message_nowait(mid, package)
+            self._persistent_storage.push_message(mid, package)
 
     def _send_simple_command(self, cmd):
         self._connection.send_simple_command(cmd)
 
     def _send_command_with_mid(self, cmd, mid, dup, reason_code=0):
         self._connection.send_command_with_mid(cmd, mid, dup, reason_code=reason_code)
-
-    @property
-    def protocol_version(self):
-        return self._connection._protocol.proto_ver \
-            if self._connection is not None else MQTTv50

--- a/gmqtt/client.py
+++ b/gmqtt/client.py
@@ -3,13 +3,13 @@ import json
 import logging
 import uuid
 from functools import partial
-from typing import Sequence, Union
 
 from .mqtt.connection import MQTTConnection
 from .mqtt.constants import UNLIMITED_RECONNECTS, MQTTv50
 from .mqtt.handler import MqttPackageHandler
 from .mqtt.utils import ConnectionState
 from .storage import PersistentStorage
+from .subscription import SubscriptionsHandlerMixin
 
 
 class Message:
@@ -38,126 +38,6 @@ class Message:
 
         if self.payload_size > 268435455:
             raise ValueError("Payload too large.")
-
-
-class Subscription:
-    def __init__(
-        self,
-        topic,
-        qos=0,
-        no_local=False,
-        retain_as_published=False,
-        retain_handling_options=0,
-        subscription_identifier=None,
-    ):
-        self.topic = topic
-        self.qos = qos
-        self.no_local = no_local
-        self.retain_as_published = retain_as_published
-        self.retain_handling_options = retain_handling_options
-
-        self.mid = None
-        self.acknowledged = False
-
-        # this property can be used only in MQTT5.0
-        self.subscription_identifier = subscription_identifier
-
-
-class SubscriptionsHandlerMixin:
-    def __init__(self):
-        self.subscriptions = []
-        # defined by a main class
-        self._connection = None
-
-    def update_subscriptions_with_subscription_or_topic(
-        self,
-        subscription_or_topic,
-        qos,
-        no_local,
-        retain_as_published,
-        retain_handling_options,
-        kwargs,
-    ):
-
-        sentinel = object()
-        subscription_identifier = kwargs.get("subscription_identifier", sentinel)
-
-        if isinstance(subscription_or_topic, Subscription):
-
-            if subscription_identifier is not sentinel:
-                subscription_or_topic.subscription_identifier = subscription_identifier
-
-            subscriptions = [subscription_or_topic]
-        elif isinstance(subscription_or_topic, (tuple, list)):
-
-            if subscription_identifier is not sentinel:
-                for sub in subscription_or_topic:
-                    sub.subscription_identifier = subscription_identifier
-
-            subscriptions = subscription_or_topic
-        elif isinstance(subscription_or_topic, str):
-
-            if subscription_identifier is sentinel:
-                subscription_identifier = None
-
-            subscriptions = [
-                Subscription(
-                    subscription_or_topic,
-                    qos=qos,
-                    no_local=no_local,
-                    retain_as_published=retain_as_published,
-                    retain_handling_options=retain_handling_options,
-                    subscription_identifier=subscription_identifier,
-                )
-            ]
-        else:
-            raise ValueError(
-                "Bad subscription: must be string or Subscription or list of Subscriptions"
-            )
-        self.subscriptions.extend(subscriptions)
-        return subscriptions
-
-    def _remove_subscriptions(self, topic: Union[str, Sequence[str]]):
-        if isinstance(topic, str):
-            self.subscriptions = [s for s in self.subscriptions if s.topic != topic]
-        else:
-            self.subscriptions = [s for s in self.subscriptions if s.topic not in topic]
-
-    def subscribe(
-        self,
-        subscription_or_topic: Union[str, Subscription, Sequence[Subscription]],
-        qos=0,
-        no_local=False,
-        retain_as_published=False,
-        retain_handling_options=0,
-        **kwargs
-    ):
-
-        # Warn: if you will pass a few subscriptions objects, and each will be have different
-        # subscription identifier - the only first will be used as identifier
-        # if only you will not pass the identifier in kwargs
-
-        subscriptions = self.update_subscriptions_with_subscription_or_topic(
-            subscription_or_topic,
-            qos,
-            no_local,
-            retain_as_published,
-            retain_handling_options,
-            kwargs,
-        )
-        return self._connection.subscribe(subscriptions, **kwargs)
-
-    def resubscribe(self, subscription: Subscription, **kwargs):
-        # send subscribe packet for subscription,that's already in client's subscription list
-        if "subscription_identifier" in kwargs:
-            subscription.subscription_identifier = kwargs["subscription_identifier"]
-        elif subscription.subscription_identifier is not None:
-            kwargs["subscription_identifier"] = subscription.subscription_identifier
-        return self._connection.subscribe([subscription], **kwargs)
-
-    def unsubscribe(self, topic: Union[str, Sequence[str]], **kwargs):
-        self._remove_subscriptions(topic)
-        return self._connection.unsubscribe(topic, **kwargs)
 
 
 class Client(SubscriptionsHandlerMixin):
@@ -371,8 +251,7 @@ class Client(SubscriptionsHandlerMixin):
 
     def _remove_message_from_queue(self, mid):
         self._logger.debug("[Client] remove message. mid: %s", mid)
-        future = asyncio.ensure_future(self._persistent_storage.remove_message_by_mid(mid))
-        future.add_done_callback(partial(self._handle_exception_in_future, msg="remove message"))
+        self._persistent_storage.remove_message_by_mid(mid)
 
     @property
     def is_connected(self):
@@ -382,23 +261,23 @@ class Client(SubscriptionsHandlerMixin):
     async def _resend_qos_messages(self):
         await self._connack_received.wait()
 
-        if await self._persistent_storage.is_empty:
+        if self._persistent_storage.is_empty:
             self._logger.debug("[Client] QoS queue is empty, nothing to replay")
             return
         elif self._connection.is_closing():
             self._logger.warning(
                 "[Client] transport already closing, skipping replay of %s message(s) — "
                 "next reconnect will retry",
-                len(await self._persistent_storage.get_all()),
+                len(self._persistent_storage.get_all()),
             )
             return
         else:
-            msgs = await self._persistent_storage.get_all()
+            msgs = self._persistent_storage.get_all()
             self._logger.debug(
                 "[Client] replaying %s inflight message(s)", len(msgs)
             )
 
-            await self._persistent_storage.clear()
+            self._persistent_storage.clear()
 
             for mid, package in msgs:
                 try:
@@ -411,8 +290,8 @@ class Client(SubscriptionsHandlerMixin):
 
                 self._persistent_storage.push_message(mid, package)
 
-    async def _clear_resend_qos_queue(self):
-        await self._persistent_storage.clear()
+    def _clear_resend_qos_queue(self):
+        self._persistent_storage.clear()
 
     def set_auth_credentials(self, username, password=None):
         self._username = username.encode()

--- a/gmqtt/mqtt/connection.py
+++ b/gmqtt/mqtt/connection.py
@@ -1,11 +1,16 @@
 import asyncio
 import logging
 import time
+from functools import partial
 
+from .handler import MqttPackageHandler
 from .protocol import MQTTProtocol
+from .package import Package
+from .utils import ConnectionState
 
-class MQTTConnection(object):
-    def __init__(self, transport: asyncio.Transport, protocol: MQTTProtocol, clean_session: bool, keepalive: int, logger=None):
+class MQTTConnection:
+    def __init__(self, transport: asyncio.Transport, protocol: MQTTProtocol, clean_session: bool, keepalive: int,
+                 package_handler: MqttPackageHandler, logger=None):
         self._transport = transport
         self._protocol = protocol
         self._protocol.set_connection(self)
@@ -20,12 +25,15 @@ class MQTTConnection(object):
         self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive / 2, self._keep_connection)
 
         self._logger = logger or logging.getLogger(__name__)
+        self._handler = package_handler
 
     @classmethod
-    async def create_connection(cls, host, port, ssl, clean_session, keepalive, loop=None, logger=None):
+    async def create_connection(cls, host, port, ssl, clean_session, keepalive, connection_state: ConnectionState,
+                                package_handler: MqttPackageHandler, loop=None, logger=None):
         loop = loop or asyncio.get_event_loop()
-        transport, protocol = await loop.create_connection(MQTTProtocol, host, port, ssl=ssl)
-        return MQTTConnection(transport, protocol, clean_session, keepalive, logger=logger)
+        protocol_factory = partial(MQTTProtocol, connection_state=connection_state, id_generator=package_handler.id_generator)
+        transport, protocol = await loop.create_connection(protocol_factory, host, port, ssl=ssl)
+        return MQTTConnection(transport, protocol, clean_session, keepalive, package_handler=package_handler, logger=logger)
 
     def _keep_connection(self):
         if self.is_closing() or not self._keepalive:
@@ -42,9 +50,9 @@ class MQTTConnection(object):
             self._send_ping_request()
         self._keep_connection_callback = asyncio.get_event_loop().call_later(self._keepalive / 2, self._keep_connection)
 
-    def put_package(self, pkg):
+    def put_package(self, pkg: Package):
         self._last_data_in = time.monotonic()
-        self._handler(*pkg)
+        self._handler(pkg)
 
     def send_package(self, package):
         # This is not blocking operation, because transport place the data
@@ -82,14 +90,17 @@ class MQTTConnection(object):
     def _send_ping_request(self):
         self._protocol.send_ping_request()
 
-    def set_handler(self, handler):
-        self._handler = handler
-
     async def close(self):
         if self._keep_connection_callback:
             self._keep_connection_callback.cancel()
         self._transport.close()
-        await self._protocol.closed
+        try:
+            await self._protocol.closed
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError) as exc:
+            # The broker closed the socket forcefully (common on TLS after DISCONNECT).
+            # App called the close(), so the connection is gone either way.
+            # The WARNING is already emitted by connection_lost(); no need to re-raise.
+            self._logger.debug("[CLOSE] suppressed transport error after intentional close: %s", exc)
 
     def is_closing(self):
         return self._transport.is_closing()

--- a/gmqtt/mqtt/handler.py
+++ b/gmqtt/mqtt/handler.py
@@ -15,6 +15,7 @@ from .utils import (
     run_coroutine_or_function,
     unpack_variable_byte_integer,
 )
+from ..subscription import Subscription
 
 
 def _empty_callback(*args, **kwargs):
@@ -152,12 +153,12 @@ class MqttPackageHandler(EventCallbackMixin):
         *args,
         connack_event: asyncio.Event,
         connection_state: ConnectionState,
-        reconnect_callback: Callable[..., Awaitable],
-        disconnect_callback: Callable[..., Awaitable],
-        resend_qos_callback: Callable[[], Awaitable],
-        clear_qos_callback: Callable[[], Awaitable],
+        reconnect_callback: Callable[..., Awaitable[None]],
+        disconnect_callback: Callable[..., Awaitable[None]],
+        resend_qos_callback: Callable[[], Awaitable[None]],
+        clear_qos_callback: Callable[[], None],
         connect_properties: dict,
-        subscriptions_getter: Callable[[], List],
+        subscriptions_getter: Callable[[], List[Subscription]],
         remove_message_callback: Callable[[int], None],
         send_command_with_mid_callback: Callable[..., None],
         receive_maximum: int = 65535,
@@ -374,7 +375,7 @@ class MqttPackageHandler(EventCallbackMixin):
         if session_present:
             asyncio.ensure_future(self._resend_qos_callback())
         else:
-            asyncio.ensure_future(self._clear_qos_callback())
+            self._clear_qos_callback()
 
         self._logger.debug(
             "[MqttPackageHandler] session_present: %s, result: %s",

--- a/gmqtt/mqtt/handler.py
+++ b/gmqtt/mqtt/handler.py
@@ -3,14 +3,18 @@ import logging
 import struct
 import time
 from collections import defaultdict
-from copy import deepcopy
 from functools import partial
+from typing import Awaitable, Callable, List, Optional
 
-from .utils import unpack_variable_byte_integer, IdGenerator, run_coroutine_or_function
+from .constants import MQTTCommands, MQTTv50, MQTTv311, PubRecReasonCode
+from .package import Package
 from .property import Property
-from .protocol import MQTTProtocol
-from .constants import MQTTCommands, PubRecReasonCode, DEFAULT_CONFIG
-from .constants import MQTTv311, MQTTv50
+from .utils import (
+    IdGenerator,
+    ConnectionState,
+    run_coroutine_or_function,
+    unpack_variable_byte_integer,
+)
 
 
 def _empty_callback(*args, **kwargs):
@@ -28,7 +32,7 @@ class MQTTConnectError(MQTTError):
         3: "Connection Refused: broker unavailable",
         4: "Connection Refused: bad user name or password",
         5: "Connection Refused: not authorised",
-        10: 'Cannot handle CONNACK package',
+        10: "Cannot handle CONNACK package",
         128: "Connection Refused: Unspecified error",
         129: "Connection Refused: Malformed Packet",
         130: "Connection Refused: Protocol Error",
@@ -54,18 +58,17 @@ class MQTTConnectError(MQTTError):
 
     def __init__(self, code):
         self._code = code
-        self.message = self.__messages__.get(code, 'Unknown error')\
-
+        self.message = self.__messages__.get(code, "Unknown error")
 
     def __str__(self):
         return "code {} ({})".format(self._code, self.message)
 
 
-class EventCallback(object):
-    def __init__(self, *args, **kwargs):
-        super(EventCallback, self).__init__()
+class EventCallbackMixin:
 
-        self._connected = asyncio.Event()
+    def __init__(self, *args, **kwargs):
+        # provided by a main class
+        self._connection_state: ConnectionState
 
         self._on_connected_callback = _empty_callback
         self._on_disconnected_callback = _empty_callback
@@ -73,42 +76,24 @@ class EventCallback(object):
         self._on_subscribe_callback = _empty_callback
         self._on_unsubscribe_callback = _empty_callback
 
-        self._config = deepcopy(DEFAULT_CONFIG)
-        self._reconnecting_now = False
-
-        # this flag should be True after connect and False when disconnect was called
-        self._is_active = False
-
-        self.failed_connections = 0
-
-    def _temporatily_stop_reconnect(self):
-        self._reconnecting_now = True
-
-    def _exit_reconnecting_state(self):
-        self._reconnecting_now = False
-
     def stop_reconnect(self):
-        self._config['reconnect_retries'] = 0
-
-    def set_config(self, config):
-        self._config.update(config)
+        self._connection_state.config["reconnect_retries"] = 0
 
     @property
     def reconnect_delay(self):
-        return self._config['reconnect_delay']
+        return self._connection_state.config["reconnect_delay"]
 
     @reconnect_delay.setter
     def reconnect_delay(self, value):
-        self._config['reconnect_delay'] = value
+        self._connection_state.config["reconnect_delay"] = value
 
     @property
     def reconnect_retries(self):
-        return self._config['reconnect_retries']
+        return self._connection_state.config["reconnect_retries"]
 
     @reconnect_retries.setter
     def reconnect_retries(self, value):
-        self._config['reconnect_retries'] = value
-
+        self._connection_state.config["reconnect_retries"] = value
 
     @property
     def on_subscribe(self):
@@ -161,76 +146,143 @@ class EventCallback(object):
         self._on_unsubscribe_callback = cb
 
 
-class MqttPackageHandler(EventCallback):
-    def __init__(self, *args, **kwargs):
-        super(MqttPackageHandler, self).__init__(*args, **kwargs)
+class MqttPackageHandler(EventCallbackMixin):
+    def __init__(
+        self,
+        *args,
+        connack_event: asyncio.Event,
+        connection_state: ConnectionState,
+        reconnect_callback: Callable[..., Awaitable],
+        disconnect_callback: Callable[..., Awaitable],
+        resend_qos_callback: Callable[[], Awaitable],
+        clear_qos_callback: Callable[[], Awaitable],
+        connect_properties: dict,
+        subscriptions_getter: Callable[[], List],
+        remove_message_callback: Callable[[int], None],
+        send_command_with_mid_callback: Callable[..., None],
+        receive_maximum: int = 65535,
+        optimistic_acknowledgement: bool = True,
+        logger: Optional[logging.Logger] = None,
+        **kwargs
+    ):
+
+        super().__init__(*args, **kwargs)
+
+        self._connack_received = connack_event
+        self._connection_state = connection_state
+        self._reconnect_callback = reconnect_callback
+        self._disconnect_callback = disconnect_callback
+        self._resend_qos_callback = resend_qos_callback
+        self._clear_qos_callback = clear_qos_callback
+        self._connect_properties = connect_properties
+        self._subscriptions_getter = subscriptions_getter
+        self._remove_message_callback = remove_message_callback
+        self._send_command_with_mid_callback = send_command_with_mid_callback
+        self._connack_properties: dict = {}
         self._messages_in = {}
         self._handler_cache = {}
         self._error = None
         self._connection = None
         self._server_topics_aliases = {}
 
-        self._id_generator = IdGenerator(max=kwargs.get('receive_maximum', 65535))
+        if connection_state.protocol_version < MQTTv50:
+            optimistic_acknowledgement = True
 
-        if self.protocol_version == MQTTv50:
-            self._optimistic_acknowledgement = kwargs.get('optimistic_acknowledgement', True)
-        else:
-            self._optimistic_acknowledgement = True
+        self._optimistic_acknowledgement = optimistic_acknowledgement
+        self.id_generator = IdGenerator(max=receive_maximum)
 
-        self._logger = kwargs.get('logger', logging.getLogger(__name__))
+        self._logger = logger or logging.getLogger(__name__)
 
-    def _clear_topics_aliases(self):
+    @property
+    def has_error(self):
+        return self._error is not None
+
+    @property
+    def properties(self) -> dict:
+        """Merged connect + connack properties, passed to the on_connect callback."""
+        return {**self._connack_properties, **self._connect_properties}
+
+    def propagate_error(self):
+        if self._error:
+            raise self._error
+
+    def get_subscriptions_by_mid(self, mid: int) -> List:
+        return [sub for sub in self._subscriptions_getter() if sub.mid == mid]
+
+    def clear_topics_aliases(self):
         self._server_topics_aliases = {}
 
     def _send_command_with_mid(self, cmd, mid, dup, reason_code=0):
-        raise NotImplementedError
+        self._send_command_with_mid_callback(cmd, mid, dup, reason_code=reason_code)
 
-    def _remove_message_from_query(self, mid):
-        raise NotImplementedError
+    def _remove_message_from_queue(self, mid: int) -> None:
+        self._remove_message_callback(mid)
 
     def _send_puback(self, mid, reason_code=0):
-        self._send_command_with_mid(MQTTCommands.PUBACK, mid, False, reason_code=reason_code)
+        self._send_command_with_mid(
+            MQTTCommands.PUBACK, mid, False, reason_code=reason_code
+        )
 
     def _send_pubrec(self, mid, reason_code=0):
-        self._send_command_with_mid(MQTTCommands.PUBREC, mid, False, reason_code=reason_code)
+        self._send_command_with_mid(
+            MQTTCommands.PUBREC, mid, False, reason_code=reason_code
+        )
 
     def _send_pubrel(self, mid, dup, reason_code=0):
-        self._send_command_with_mid(MQTTCommands.PUBREL | 2, mid, dup, reason_code=reason_code)
+        self._send_command_with_mid(
+            MQTTCommands.PUBREL | 2, mid, dup, reason_code=reason_code
+        )
 
     def _send_pubcomp(self, mid, dup, reason_code=0):
-        self._send_command_with_mid(MQTTCommands.PUBCOMP, mid, dup, reason_code=reason_code)
+        self._send_command_with_mid(
+            MQTTCommands.PUBCOMP, mid, dup, reason_code=reason_code
+        )
+
+    def _default_cmd_handler(self, cmd, packet):
+        self._logger.warning("[MqttPackageHandler] %s %s", hex(cmd), packet)
 
     def __get_handler__(self, cmd):
         cmd_type = cmd & 0xF0
         if cmd_type not in self._handler_cache:
-            handler_name = '_handle_{}_packet'.format(MQTTCommands(cmd_type).name.lower())
-            self._handler_cache[cmd_type] = getattr(self, handler_name, self._default_handler)
+            handler_name = "_handle_{}_packet".format(
+                MQTTCommands(cmd_type).name.lower()
+            )
+            self._handler_cache[cmd_type] = getattr(
+                self, handler_name, self._default_cmd_handler
+            )
         return self._handler_cache[cmd_type]
 
     def _handle_packet(self, cmd, packet):
-        self._logger.debug('[CMD %s] %s', hex(cmd), packet)
+        self._logger.debug("[MqttPackageHandler] cmd: %s, packet: %s", hex(cmd), packet)
         handler = self.__get_handler__(cmd)
         handler(cmd, packet)
         self._last_msg_in = time.monotonic()
 
-    def _handle_exception_in_future(self, future):
-        if future.exception():
-            self._logger.warning('[EXC OCCURED] in reconnect future %s', future.exception())
-            return
+    def _handle_exception_in_future(self, future, msg=None):
+        """Done-callback for fire-and-forget futures.
 
-    def _default_handler(self, cmd, packet):
-        self._logger.warning('[UNKNOWN CMD] %s %s', hex(cmd), packet)
+        msg: string to be added to the log message with the exception itself
+        """
+        exc = future.exception()
+        log_string = "[MqttPackageHandler]: %s"
+        if msg:
+            log_string = "[MqttPackageHandler] " + msg + ": %s"
+
+        if exc:
+            self._logger.warning(log_string, exc)
 
     def _handle_disconnect_packet(self, cmd, packet):
         # reset server topics on disconnect
-        self._clear_topics_aliases()
+        self.clear_topics_aliases()
 
-        future = asyncio.ensure_future(self.reconnect(delay=True))
-        future.add_done_callback(self._handle_exception_in_future)
-        self.on_disconnect(self, packet)
+        future = asyncio.ensure_future(self._reconnect_callback(delay=True))
+        future.add_done_callback(
+            partial(self._handle_exception_in_future, msg="reconnect failed")
+        )
+        self.on_disconnect(packet)
 
     def _parse_properties(self, packet):
-        if self.protocol_version < MQTTv50:
+        if self._connection_state.protocol_version < MQTTv50:
             # If protocol is version is less than 5.0, there is no properties in packet
             return {}, packet
         properties_len, left_packet = unpack_variable_byte_integer(packet)
@@ -238,10 +290,13 @@ class MqttPackageHandler(EventCallback):
         left_packet = left_packet[properties_len:]
         properties_dict = defaultdict(list)
         while packet:
-            property_identifier, = struct.unpack("!B", packet[:1])
+            (property_identifier,) = struct.unpack("!B", packet[:1])
             property_obj = Property.factory(id_=property_identifier)
             if property_obj is None:
-                self._logger.critical('[PROPERTIES] received invalid property id {}, disconnecting'.format(property_identifier))
+                self._logger.critical(
+                    "[MqttPackageHandler] received invalid property id %s, disconnecting",
+                    property_identifier
+                )
                 return None, None
             result, packet = property_obj.loads(packet[1:])
             for k, v in result.items():
@@ -250,49 +305,82 @@ class MqttPackageHandler(EventCallback):
         return properties_dict, left_packet
 
     def _update_keepalive_if_needed(self):
-        if not self._connack_properties.get('server_keep_alive'):
+        if not self._connack_properties.get("server_keep_alive"):
             return
-        self._keepalive = self._connack_properties['server_keep_alive'][0]
+        self._keepalive = self._connack_properties["server_keep_alive"][0]
         self._connection.keepalive = self._keepalive
 
     def _handle_connack_packet(self, cmd, packet):
-        self._connected.set()
-
         (session_present, result) = struct.unpack("!BB", packet[:2])
-        if session_present:
-            asyncio.ensure_future(self._resend_qos_messages())
-        else:
-            asyncio.ensure_future(self._clear_resend_qos_queue())
 
+        # --- Step 1: check result before any side-effects ---
         if result != 0:
-            self._logger.warning('[CONNACK] %s', hex(result))
-            self.failed_connections += 1
-            if result == 1 and self.protocol_version == MQTTv50:
-                self._logger.info('[CONNACK] Downgrading to MQTT 3.1 protocol version')
-                MQTTProtocol.proto_ver = MQTTv311
-                future = asyncio.ensure_future(self.reconnect(delay=True))
-                future.add_done_callback(self._handle_exception_in_future)
-                return
-            else:
-                self._error = MQTTConnectError(result)
-                asyncio.ensure_future(self.reconnect(delay=True))
-                return
-        else:
-            self.failed_connections = 0
+            self._logger.warning("[MqttPackageHandler] CONNACK: %s", hex(result))
+            self._connection_state.failed_connections += 1
 
+            if result == 1 and self._connection_state.protocol_version == MQTTv50:
+                # Broker rejected MQTT v5; downgrade to v3.1.1 and retry.
+                # Do NOT set _connack_received here — Client.connect() must keep
+                # waiting until the subsequent successful CONNACK arrives.
+                self._logger.info("[MqttPackageHandler] Downgrading to MQTT 3.1 protocol version")
+                self._connection_state.protocol_version = MQTTv311
+                future = asyncio.ensure_future(self._reconnect_callback(delay=True))
+                future.add_done_callback(
+                    partial(self._handle_exception_in_future,
+                            msg="reconnect failed on protocol downgrade")
+                )
+            else:
+                # Permanent or transient failure: record error and unblock
+                # connect() so it can raise via propagate_error().
+                self._error = MQTTConnectError(result)
+                self._connack_received.set()
+                future = asyncio.ensure_future(self._reconnect_callback(delay=True))
+                future.add_done_callback(
+                    partial(self._handle_exception_in_future,
+                            msg="reconnect failed after refused CONNACK")
+                )
+
+            return
+
+        # --- Step 2: successful CONNACK ---
+        self._connection_state.failed_connections = 0
+
+        # --- Step 3: parse MQTT 5.0 properties (if present) ---
         if len(packet) > 2:
             properties, _ = self._parse_properties(packet[2:])
             if properties is None:
+                # Malformed properties — set error and return before touching
+                # any mutable state (fixes the None-assignment crash).
                 self._error = MQTTConnectError(10)
-                asyncio.ensure_future(self.disconnect())
+                self._connack_received.set()
+                self._logger.warning(
+                    "[MqttPackageHandler] malformed properties: disconnecting (code 10)"
+                )
+                self.on_disconnect(self._error)
+                asyncio.ensure_future(self._disconnect_callback())
+                return
+
             self._connack_properties = properties
             self._update_keepalive_if_needed()
 
-        # TODO: Implement checking for the flags and results
-        # see 3.2.2.3 Connect Return code of the http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.pdf
+            # --- Step 4: apply broker's flow-control window ---
+            if "receive_maximum" in self._connack_properties:
+                self.id_generator._max = self._connack_properties["receive_maximum"][0]
 
-        self._logger.debug('[CONNACK] session_present: %s, result: %s', hex(session_present), hex(result))
-        self.on_connect(self, session_present, result, self.properties)
+        # --- Step 5: all state is consistent — unblock connect() ---
+        self._connack_received.set()
+
+        # --- Step 6: schedule QoS session-restore only on success ---
+        if session_present:
+            asyncio.ensure_future(self._resend_qos_callback())
+        else:
+            asyncio.ensure_future(self._clear_qos_callback())
+
+        self._logger.debug(
+            "[MqttPackageHandler] session_present: %s, result: %s",
+            hex(session_present), hex(result),
+        )
+        self.on_connect(session_present, result, self.properties)
 
     def _handle_publish_packet(self, cmd, raw_packet):
         header = cmd
@@ -301,93 +389,115 @@ class MqttPackageHandler(EventCallback):
         qos = (header & 0x06) >> 1
         retain = header & 0x01
 
-        pack_format = "!H" + str(len(raw_packet) - 2) + 's'
+        pack_format = "!H" + str(len(raw_packet) - 2) + "s"
         (slen, packet) = struct.unpack(pack_format, raw_packet)
 
-        pack_format = '!' + str(slen) + 's' + str(len(packet) - slen) + 's'
+        pack_format = "!" + str(slen) + "s" + str(len(packet) - slen) + "s"
         (topic, packet) = struct.unpack(pack_format, packet)
 
         # we will change the packet ref, let's save origin
         payload = packet
 
         if qos > 0:
-            pack_format = "!H" + str(len(packet) - 2) + 's'
+            pack_format = "!H" + str(len(packet) - 2) + "s"
             (mid, packet) = struct.unpack(pack_format, packet)
         else:
             mid = None
 
         properties, packet = self._parse_properties(packet)
-        properties['dup'] = dup
-        properties['retain'] = retain
+        properties["dup"] = dup
+        properties["retain"] = retain
 
         if packet is None:
-            self._logger.critical('[INVALID MESSAGE] skipping: {}'.format(raw_packet))
+            self._logger.critical("[MqttPackageHandler] invalid message. Skipping: {}".format(raw_packet))
             return
 
-        if 'topic_alias' in properties:
+        if "topic_alias" in properties:
             # TODO: need to add validation (topic alias must be greater than 0 and less than topic_alias_maximum)
-            topic_alias = properties['topic_alias'][0]
+            topic_alias = properties["topic_alias"][0]
             if topic:
                 self._server_topics_aliases[topic_alias] = topic
             else:
                 topic = self._server_topics_aliases.get(topic_alias, None)
 
         if not topic:
-            self._logger.warning('[MQTT ERR PROTO] topic name is empty (or server has send invalid topic alias)')
+            self._logger.warning(
+                "[MqttPackageHandler] topic name is empty (or server has send invalid topic alias)"
+            )
             return
 
         try:
-            print_topic = topic.decode('utf-8')
+            print_topic = topic.decode("utf-8")
         except UnicodeDecodeError as exc:
-            self._logger.warning('[INVALID CHARACTER IN TOPIC] %s', topic, exc_info=exc)
+            self._logger.warning("[MqttPackageHandler] invalid character in topic: %s", topic, exc_info=exc)
             print_topic = topic
 
-        self._logger.debug('[RECV %s with QoS: %s] %s', print_topic, qos, payload)
+        self._logger.debug("[MqttPackageHandler] RECV %s, QoS: %s, payload: %s", print_topic, qos, payload)
 
         if qos == 0:
-            run_coroutine_or_function(self.on_message, self, print_topic, packet, qos, properties)
+            run_coroutine_or_function(
+                self.on_message, print_topic, packet, qos, properties
+            )
         elif qos == 1:
             self._handle_qos_1_publish_packet(mid, packet, print_topic, properties)
         elif qos == 2:
             self._handle_qos_2_publish_packet(mid, packet, print_topic, properties)
-        self._id_generator.free_id(mid)
+        # NOTE: do NOT free `mid` here. It is the BROKER's packet identifier for
+        # an inbound PUBLISH and lives in a namespace independent of our
+        # outbound allocator. Freeing it could remove an inflight outbound mid
+        # from the pool and cause MQTT-2.2.1-3 violations.
 
     def _handle_qos_2_publish_packet(self, mid, packet, print_topic, properties):
         if self._optimistic_acknowledgement:
             self._send_pubrec(mid)
-            run_coroutine_or_function(self.on_message, self, print_topic, packet, 2, properties)
+            run_coroutine_or_function(
+                self.on_message, print_topic, packet, 2, properties
+            )
         else:
-            run_coroutine_or_function(self.on_message, self, print_topic, packet, 2, properties,
-                                      callback=partial(self.__handle_publish_callback, qos=2, mid=mid))
+            run_coroutine_or_function(
+                self.on_message,
+                print_topic,
+                packet,
+                2,
+                properties,
+                callback=partial(self.__handle_publish_callback, qos=2, mid=mid),
+            )
 
     def __handle_publish_callback(self, f, qos=None, mid=None):
         reason_code = f.result()
         if reason_code not in (c.value for c in PubRecReasonCode):
-            raise ValueError('Invalid PUBREC reason code {}'.format(reason_code))
+            raise ValueError("Invalid PUBREC reason code {}".format(reason_code))
         if qos == 2:
             self._send_pubrec(mid, reason_code=reason_code)
         else:
             self._send_puback(mid, reason_code=reason_code)
-        self._id_generator.free_id(mid)
+        # NOTE: do NOT free `mid` here — it is the broker's inbound mid, not the
+        # one we allocated. See _handle_publish_packet for the full rationale.
 
     def _handle_qos_1_publish_packet(self, mid, packet, print_topic, properties):
         if self._optimistic_acknowledgement:
             self._send_puback(mid)
-            run_coroutine_or_function(self.on_message, self, print_topic, packet, 1, properties)
+            run_coroutine_or_function(
+                self.on_message, print_topic, packet, 1, properties
+            )
         else:
-            run_coroutine_or_function(self.on_message, self, print_topic, packet, 1, properties,
-                                      callback=partial(self.__handle_publish_callback, qos=1, mid=mid))
+            run_coroutine_or_function(
+                self.on_message,
+                print_topic,
+                packet,
+                1,
+                properties,
+                callback=partial(self.__handle_publish_callback, qos=1, mid=mid),
+            )
 
-    def __call__(self, cmd, packet):
+    def __call__(self, package: Package):
         try:
-            result = self._handle_packet(cmd, packet)
-        except Exception as exc:
-            self._logger.error('[ERROR HANDLE PKG]', exc_info=exc)
-            result = None
-        return result
+            self._handle_packet(package.cmd, package.data)
+        except Exception:
+            self._logger.exception("[MqttPackageHandler] error handling package")
 
     def _handle_suback_packet(self, cmd, raw_packet):
-        pack_format = "!H" + str(len(raw_packet) - 2) + 's'
+        pack_format = "!H" + str(len(raw_packet) - 2) + "s"
         (mid, packet) = struct.unpack(pack_format, raw_packet)
         properties, packet = self._parse_properties(packet)
 
@@ -403,55 +513,56 @@ class MqttPackageHandler(EventCallback):
                 sub.acknowledged = True
                 sub.qos = granted_qos
 
-        self._logger.info('[SUBACK] %s %s', mid, granted_qoses)
-        self.on_subscribe(self, mid, granted_qoses, properties)
+        self._logger.info("[MqttPackageHandler] SUBACK mid: %s, QoS: %s", mid, granted_qoses)
+        self.on_subscribe(mid, granted_qoses, properties)
 
-        for sub in self.subscriptions:
+        for sub in self._subscriptions_getter():
             if sub.mid == mid:
                 sub.mid = None
-        self._id_generator.free_id(mid)
+
+        self.id_generator.free_id(mid)
 
     def _handle_unsuback_packet(self, cmd, raw_packet):
-        pack_format = "!H" + str(len(raw_packet) - 2) + 's'
+        pack_format = "!H" + str(len(raw_packet) - 2) + "s"
         (mid, packet) = struct.unpack(pack_format, raw_packet)
         pack_format = "!" + "B" * len(packet)
         granted_qos = struct.unpack(pack_format, packet)
 
-        self._logger.info('[UNSUBACK] %s %s', mid, granted_qos)
+        self._logger.info("[MqttPackageHandler] UNSUBACK mid: %s, QoS: %s", mid, granted_qos)
 
-        self.on_unsubscribe(self, mid, granted_qos)
-        self._id_generator.free_id(mid)
+        self.on_unsubscribe(mid, granted_qos)
+        self.id_generator.free_id(mid)
 
     def _handle_pingreq_packet(self, cmd, packet):
-        self._logger.debug('[PING REQUEST] %s %s', hex(cmd), packet)
+        self._logger.debug("[MqttPackageHandler] PINGREQ cmd: %s, packet: %s", hex(cmd), packet)
         pass
 
     def _handle_pingresp_packet(self, cmd, packet):
-        self._logger.debug('[PONG REQUEST] %s %s', hex(cmd), packet)
+        self._logger.debug("[MqttPackageHandler] PINGRESP cmd: %s, packet: %s", hex(cmd), packet)
 
     def _handle_puback_packet(self, cmd, packet):
-        (mid, ) = struct.unpack("!H", packet[:2])
+        (mid,) = struct.unpack("!H", packet[:2])
 
         # TODO: For MQTT 5.0 parse reason code and properties
 
-        self._logger.debug('[RECEIVED PUBACK FOR] %s', mid)
+        self._logger.debug("[MqttPackageHandler] PUBACK mid: %s", mid)
 
-        self._id_generator.free_id(mid)
-        self._remove_message_from_query(mid)
+        self.id_generator.free_id(mid)
+        self._remove_message_from_queue(mid)
 
     def _handle_pubcomp_packet(self, cmd, packet):
         pass
 
     def _handle_pubrec_packet(self, cmd, packet):
         (mid,) = struct.unpack("!H", packet[:2])
-        self._logger.debug('[RECEIVED PUBREC FOR] %s', mid)
-        self._id_generator.free_id(mid)
-        self._remove_message_from_query(mid)
+        self._logger.debug("[MqttPackageHandler] PUBREC mid: %s", mid)
+        self.id_generator.free_id(mid)
+        self._remove_message_from_queue(mid)
         self._send_pubrel(mid, 0)
 
     def _handle_pubrel_packet(self, cmd, packet):
-        (mid, ) = struct.unpack("!H", packet[:2])
-        self._logger.debug('[RECEIVED PUBREL FOR] %s', mid)
+        (mid,) = struct.unpack("!H", packet[:2])
+        self._logger.debug("[MqttPackageHandler] PUBREL mid: %s", mid)
         self._send_pubcomp(mid, 0)
 
-        self._id_generator.free_id(mid)
+        self.id_generator.free_id(mid)

--- a/gmqtt/mqtt/package.py
+++ b/gmqtt/mqtt/package.py
@@ -1,10 +1,11 @@
 import struct
 import logging
+from dataclasses import dataclass
 from typing import Tuple
 
 from .constants import MQTTCommands, MQTTv50
 from .property import Property
-from .utils import pack_variable_byte_integer, IdGenerator
+from .utils import pack_variable_byte_integer
 
 logger = logging.getLogger(__name__)
 
@@ -12,16 +13,14 @@ LAST_MID = 0
 USED_IDS = set()
 
 
-class Packet(object):
+@dataclass
+class Package:
     __slots__ = ['cmd', 'data']
-
-    def __init__(self, cmd, data):
-        self.cmd = cmd
-        self.data = data
+    cmd: int
+    data: bytes
 
 
-class PackageFactory(object):
-    id_generator = IdGenerator()
+class PackageFactory:
 
     @classmethod
     async def parse_package(cls, cmd, package):
@@ -128,7 +127,7 @@ class UnsubscribePacket(PackageFactory):
         packet = bytearray()
         packet.append(command)
         packet.extend(pack_variable_byte_integer(remaining_length))
-        local_mid = cls.id_generator.next_id()
+        local_mid = protocol.id_generator.next_id()
         packet.extend(struct.pack("!H", local_mid))
         packet.extend(properties)
         for t in topics:
@@ -175,7 +174,7 @@ class SubscribePacket(PackageFactory):
         packet = bytearray()
         packet.append(command)
         packet.extend(pack_variable_byte_integer(remaining_length))
-        local_mid = cls.id_generator.next_id()
+        local_mid = protocol.id_generator.next_id()
         packet.extend(struct.pack("!H", local_mid))
         packet.extend(properties)
         for s in subscriptions:
@@ -220,7 +219,7 @@ class PublishPacket(PackageFactory):
 
         if message.qos > 0:
             # For message id
-            mid = cls.id_generator.next_id()
+            mid = protocol.id_generator.next_id()
             packet.extend(struct.pack("!H", mid))
         else:
             mid = None

--- a/gmqtt/mqtt/property.py
+++ b/gmqtt/mqtt/property.py
@@ -88,7 +88,7 @@ PROPERTIES = [
     Property(8, 'u8', 'response_topic', ['PUBLISH', ]),
     Property(9, 'b', 'correlation_data', ['PUBLISH']),
     Property(11, 'vbi', 'subscription_identifier', ['PUBLISH', 'SUBSCRIBE']),
-    Property(17, '!L', 'session_expiry_interval', ['CONNECT', ]),
+    Property(17, '!L', 'session_expiry_interval', ['CONNECT', 'CONNACK', 'DISCONNECT']),
     Property(18, 'u8', 'assigned_client_identifier', ['CONNACK', ]),
     Property(19, '!H', 'server_keep_alive', ['CONNACK']),
     Property(21, 'u8', 'auth_method', ['CONNECT', 'CONNACK', 'AUTH']),

--- a/gmqtt/mqtt/protocol.py
+++ b/gmqtt/mqtt/protocol.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
 import time
-
 import sys
 
 from . import package
-from .constants import MQTTv50, MQTTCommands
+from .constants import MQTTCommands
+from .package import Package
+from .utils import ConnectionState, IdGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -95,15 +96,22 @@ class BaseMQTTProtocol(_StreamReaderProtocolCompatibilityMixin, asyncio.StreamRe
 
 class MQTTProtocol(BaseMQTTProtocol):
     proto_name = b'MQTT'
-    proto_ver = MQTTv50
 
-    def __init__(self, *args, **kwargs):
-        super(MQTTProtocol, self).__init__(*args, **kwargs)
+    def __init__(self, *args, connection_state: ConnectionState, id_generator: IdGenerator,  **kwargs):
+        super().__init__(*args, **kwargs)
+        self._connection_state = connection_state
         self._queue = asyncio.Queue()
-
         self._disconnect = asyncio.Event()
-
         self._read_loop_future = None
+        self.id_generator = id_generator
+
+    @property
+    def proto_ver(self) -> int:
+        return self._connection_state.protocol_version
+
+    @proto_ver.setter
+    def proto_ver(self, value: int):
+        self._connection_state.protocol_version = value
 
     def connection_made(self, transport: asyncio.Transport):
         super().connection_made(transport)
@@ -152,7 +160,7 @@ class MQTTProtocol(BaseMQTTProtocol):
                                                          proto_ver=self.proto_ver)
         self.write_data(pkg)
 
-    def _read_packet(self, data):
+    def _read_packet(self, data: bytes):
         parsed_size = 0
         raw_size = len(data)
         data_size = raw_size
@@ -192,12 +200,12 @@ class MQTTProtocol(BaseMQTTProtocol):
             command = data[parsed_size]
             start = parsed_size + header_size
             end = start + payload_size
-            packet = data[start:end]
+            pkg = Package(command, data[start:end])
 
             data_size -= header_size + payload_size
             parsed_size += header_size + payload_size
 
-            self._connection.put_package((command, packet))
+            self._connection.put_package(pkg)
 
         return parsed_size
 
@@ -214,15 +222,15 @@ class MQTTProtocol(BaseMQTTProtocol):
                     logger.debug("[RECV EMPTY] Connection will be reset automatically.")
                     break
                 buf = buf[parsed_size:]
-            except ConnectionResetError as exc:
-                # This connection will be closed, because we received the empty data.
-                # So we can safely break the while
+            except ConnectionResetError:
+                # This connection will be closed, because we received empty data.
+                # So we can safely break the while loop
                 logger.debug("[RECV EMPTY] Connection will be reset automatically.")
                 break
 
     def connection_lost(self, exc):
-        super(MQTTProtocol, self).connection_lost(exc)
-        self._connection.put_package((MQTTCommands.DISCONNECT, b''))
+        super().connection_lost(exc)
+        self._connection.put_package(Package(MQTTCommands.DISCONNECT, b''))
 
         if self._read_loop_future is not None:
             self._read_loop_future.cancel()

--- a/gmqtt/mqtt/utils.py
+++ b/gmqtt/mqtt/utils.py
@@ -1,23 +1,33 @@
 import asyncio
-import struct
 import logging
-
+import struct
+from copy import deepcopy
+from dataclasses import dataclass, field
 from functools import partial
+from typing import Callable
 
+from .constants import DEFAULT_CONFIG, MQTTv50
 
 logger = logging.getLogger(__name__)
 
 
-class Singleton(type):
-    _instances = {}
+@dataclass
+class ConnectionState:
+    protocol_version: int = MQTTv50
+    config: dict = field(default_factory=lambda: deepcopy(DEFAULT_CONFIG))
+    failed_connections: int = 0
+    reconnecting_now: bool = False
 
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
 
+class IdGenerator:
+    """Allocator for outbound MQTT packet identifiers (PUBLISH/SUBSCRIBE/UNSUBSCRIBE).
 
-class IdGenerator(object, metaclass=Singleton):
+    One instance per Client. The pool is NOT a process-wide singleton — two
+    Clients in the same process must have independent pools, and inbound mids
+    from the broker live in a different namespace and must never be passed to
+    free_id.
+    """
+
     def __init__(self, max=65536):
         self._max = max
         self._used_ids = set()
@@ -28,7 +38,9 @@ class IdGenerator(object, metaclass=Singleton):
 
         while not done:
             if len(self._used_ids) >= self._max - 1:
-                raise OverflowError("All ids has already used. May be your QoS query is full.")
+                raise OverflowError(
+                    "All ids has already used. May be your QoS queue is full."
+                )
 
             self._last_used_id += 1
 
@@ -45,7 +57,7 @@ class IdGenerator(object, metaclass=Singleton):
         return self._last_used_id
 
     def free_id(self, id):
-        logger.debug('FREE MID: %s', id)
+        logger.debug("FREE MID: %s", id)
         if id not in self._used_ids:
             return
 
@@ -64,7 +76,7 @@ def pack_variable_byte_integer(value):
         value, b = divmod(value, 128)
         if value > 0:
             b |= 0x80
-        remaining_bytes.extend(struct.pack('!B', b))
+        remaining_bytes.extend(struct.pack("!B", b))
         if value <= 0:
             break
     return remaining_bytes
@@ -78,38 +90,39 @@ def unpack_variable_byte_integer(bts):
         b = bts[i]
         value += (b & 0x7F) * multiplier
         if multiplier > 2097152:  # 128 * 128 * 128
-            raise ValueError('Malformed Variable Byte Integer')
+            raise ValueError("Malformed Variable Byte Integer")
         multiplier *= 128
         if b & 0x80 == 0:
             break
         i += 1
-    return value, bts[i + 1:]
+    return value, bts[i + 1 :]
 
 
 def unpack_utf8(bytes_array):
-    str_len, = struct.unpack('!H', bytes_array[:2])
-    value = bytes_array[2:2 + str_len].decode('utf-8')
-    left_str = bytes_array[2 + str_len:]
+    (str_len,) = struct.unpack("!H", bytes_array[:2])
+    value = bytes_array[2 : 2 + str_len].decode("utf-8")
+    left_str = bytes_array[2 + str_len :]
     return value, left_str
 
 
 def pack_utf8(data):
     packet = bytearray()
     if isinstance(data, str):
-        data = data.encode('utf-8')
+        data = data.encode("utf-8")
     packet.extend(struct.pack("!H", len(data)))
     packet.extend(data)
     return packet
 
 
-def iscoroutinefunction_or_partial(object):
-    if isinstance(object, partial):
-        object = object.func
-    return asyncio.iscoroutinefunction(object)
+def is_coroutine_function_or_partial(obj: Callable):
+    while isinstance(obj, partial):
+        obj = obj.func
+
+    return asyncio.iscoroutinefunction(obj)
 
 
 def run_coroutine_or_function(func, *args, callback=None, **kwargs):
-    if iscoroutinefunction_or_partial(func):
+    if is_coroutine_function_or_partial(func):
         f = asyncio.ensure_future(func(*args, **kwargs))
         if callback is not None:
             f.add_done_callback(callback)

--- a/gmqtt/storage.py
+++ b/gmqtt/storage.py
@@ -1,81 +1,60 @@
 import asyncio
-from typing import Callable, Tuple, Set
-
-import heapq
-
-
-class BasePersistentStorage(object):
-    async def push_message(self, mid, raw_package):
-        raise NotImplementedError
-
-    def push_message_nowait(self, mid, raw_package) -> asyncio.Future:
-        return asyncio.ensure_future(self.push_message(mid, raw_package))
-
-    async def pop_message(self) -> Tuple[int, bytes]:
-        raise NotImplementedError
-
-    async def remove_message_by_mid(self, mid):
-        raise NotImplementedError
-
-    @property
-    async def is_empty(self) -> bool:
-        raise NotImplementedError
-
-    async def wait_empty(self) -> None:
-        # Note that when some kinda really persistent storage is used (like Redis or smth),
-        # this method must implement an atomic transaction from async network exchange perspective.
-        raise NotImplementedError
-
-    async def clear(self):
-        raise NotImplementedError
-
-    async def get_all(self):
-        raise NotImplementedError
+from collections import OrderedDict
+from typing import Callable, Set, Tuple
 
 
-class HeapPersistentStorage(BasePersistentStorage):
+class PersistentStorage:
+    """In-memory store for inflight QoS 1/2 outbound PUBLISH packets.
+
+    Keyed by packet identifier (mid) for O(1) push and removal on PUBACK/PUBCOMP.
+    Insertion order is preserved so _resend_qos_messages replays packets in
+    send order on reconnect.
+
+    Instance variables
+    ------------------
+    _messages : OrderedDict[int, bytes]
+        Maps mid → raw packet bytes for every in-flight outbound publish.
+
+    _empty_waiters : Set[asyncio.Future]
+        Futures created by wait_empty() callers that are blocking until the
+        store drains to zero.  Resolved (set_result(None)) by _check_empty()
+        after the last message is removed, and by clear() when the store is
+        wiped in one shot.
+        """
+
     def __init__(self):
-        self._queue = []
+        self._messages: OrderedDict[int, bytes] = OrderedDict()
         self._empty_waiters: Set[asyncio.Future] = set()
 
-    def _notify_waiters(self, waiters: Set[asyncio.Future], notify: Callable[[asyncio.Future], None]) -> None:
-        while waiters:
-            notify(waiters.pop())
+    def _notify_waiters(self, notify: Callable[[asyncio.Future], None]) -> None:
+        while self._empty_waiters:
+            notify(self._empty_waiters.pop())
 
     def _check_empty(self):
-        if not self._queue:
-            self._notify_waiters(self._empty_waiters, lambda waiter: waiter.set_result(None))
+        if not self._messages:
+            self._notify_waiters(lambda waiter: waiter.set_result(None))
 
-    async def push_message(self, mid, raw_package):
-        tm = asyncio.get_event_loop().time()
-        heapq.heappush(self._queue, (tm, mid, raw_package))
-
-    async def pop_message(self):
-        (tm, mid, raw_package) = heapq.heappop(self._queue)
-
-        self._check_empty()
-        return mid, raw_package
+    def push_message(self, mid, raw_package):
+        self._messages[mid] = raw_package
 
     async def remove_message_by_mid(self, mid):
-        message = next(filter(lambda x: x[1] == mid, self._queue), None)
-        if message:
-            self._queue.remove(message)
+        if self._messages.pop(mid, None) is not None:
             self._check_empty()
-        heapq.heapify(self._queue)
 
     @property
     async def is_empty(self):
-        return not bool(self._queue)
+        return not self._messages
 
     async def wait_empty(self) -> None:
-        if self._queue:
+        if self._messages:
             waiter = asyncio.get_running_loop().create_future()
             self._empty_waiters.add(waiter)
             await waiter
 
     async def clear(self):
-        self._queue = []
-        self._notify_waiters(self._empty_waiters, lambda waiter: waiter.set_result(None))
+        self._messages.clear()
+        self._notify_waiters(lambda waiter: waiter.set_result(None))
 
     async def get_all(self):
-        return self._queue
+        # Returns a snapshot list of (mid, package) pairs in insertion order.
+        return list(self._messages.items())

--- a/gmqtt/storage.py
+++ b/gmqtt/storage.py
@@ -37,12 +37,12 @@ class PersistentStorage:
     def push_message(self, mid, raw_package):
         self._messages[mid] = raw_package
 
-    async def remove_message_by_mid(self, mid):
+    def remove_message_by_mid(self, mid):
         if self._messages.pop(mid, None) is not None:
             self._check_empty()
 
     @property
-    async def is_empty(self):
+    def is_empty(self):
         return not self._messages
 
     async def wait_empty(self) -> None:
@@ -51,10 +51,10 @@ class PersistentStorage:
             self._empty_waiters.add(waiter)
             await waiter
 
-    async def clear(self):
+    def clear(self):
         self._messages.clear()
         self._notify_waiters(lambda waiter: waiter.set_result(None))
 
-    async def get_all(self):
+    def get_all(self):
         # Returns a snapshot list of (mid, package) pairs in insertion order.
         return list(self._messages.items())

--- a/gmqtt/subscription.py
+++ b/gmqtt/subscription.py
@@ -1,0 +1,122 @@
+from typing import Sequence, Union
+
+
+class Subscription:
+    def __init__(
+        self,
+        topic,
+        qos=0,
+        no_local=False,
+        retain_as_published=False,
+        retain_handling_options=0,
+        subscription_identifier=None,
+    ):
+        self.topic = topic
+        self.qos = qos
+        self.no_local = no_local
+        self.retain_as_published = retain_as_published
+        self.retain_handling_options = retain_handling_options
+
+        self.mid = None
+        self.acknowledged = False
+
+        # this property can be used only in MQTT5.0
+        self.subscription_identifier = subscription_identifier
+
+
+class SubscriptionsHandlerMixin:
+    def __init__(self):
+        self.subscriptions: list = []
+        # defined by a main class
+        self._connection = None
+
+    def update_subscriptions_with_subscription_or_topic(
+        self,
+        subscription_or_topic,
+        qos,
+        no_local,
+        retain_as_published,
+        retain_handling_options,
+        kwargs,
+    ):
+
+        sentinel = object()
+        subscription_identifier = kwargs.get("subscription_identifier", sentinel)
+
+        if isinstance(subscription_or_topic, Subscription):
+
+            if subscription_identifier is not sentinel:
+                subscription_or_topic.subscription_identifier = subscription_identifier
+
+            subscriptions = [subscription_or_topic]
+        elif isinstance(subscription_or_topic, (tuple, list)):
+
+            if subscription_identifier is not sentinel:
+                for sub in subscription_or_topic:
+                    sub.subscription_identifier = subscription_identifier
+
+            subscriptions = subscription_or_topic
+        elif isinstance(subscription_or_topic, str):
+
+            if subscription_identifier is sentinel:
+                subscription_identifier = None
+
+            subscriptions = [
+                Subscription(
+                    subscription_or_topic,
+                    qos=qos,
+                    no_local=no_local,
+                    retain_as_published=retain_as_published,
+                    retain_handling_options=retain_handling_options,
+                    subscription_identifier=subscription_identifier,
+                )
+            ]
+        else:
+            raise ValueError(
+                "Bad subscription: must be string or Subscription or list of Subscriptions"
+            )
+        self.subscriptions.extend(subscriptions)
+        return subscriptions
+
+    def _remove_subscriptions(self, topic: Union[str, Sequence[str]]):
+        if isinstance(topic, str):
+            self.subscriptions = [s for s in self.subscriptions if s.topic != topic]
+        else:
+            self.subscriptions = [s for s in self.subscriptions if s.topic not in topic]
+
+    def subscribe(
+        self,
+        subscription_or_topic: Union[str, Subscription, Sequence[Subscription]],
+        qos=0,
+        no_local=False,
+        retain_as_published=False,
+        retain_handling_options=0,
+        **kwargs
+    ):
+
+        # Warn: if you will pass a few subscriptions objects, and each will be have different
+        # subscription identifier - the only first will be used as identifier
+        # if only you will not pass the identifier in kwargs
+
+        subscriptions = self.update_subscriptions_with_subscription_or_topic(
+            subscription_or_topic,
+            qos,
+            no_local,
+            retain_as_published,
+            retain_handling_options,
+            kwargs,
+        )
+        return self._connection.subscribe(subscriptions, **kwargs)
+
+    def resubscribe(self, subscription: Subscription, **kwargs):
+        # send subscribe packet for subscription,that's already in client's subscription list
+        if "subscription_identifier" in kwargs:
+            subscription.subscription_identifier = kwargs["subscription_identifier"]
+        elif subscription.subscription_identifier is not None:
+            kwargs["subscription_identifier"] = subscription.subscription_identifier
+        return self._connection.subscribe([subscription], **kwargs)
+
+    def unsubscribe(self, topic: Union[str, Sequence[str]], **kwargs):
+        self._remove_subscriptions(topic)
+        return self._connection.unsubscribe(topic, **kwargs)
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 norecursedirs = env pyenv
 
+log_cli = false
+log_cli_level = DEBUG
+log_cli_format = %(asctime)s,%(msecs)03d %(levelname)-8s %(name)s: %(message)s
+log_cli_date_format = %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-import sys
 from os import path
 
 from setuptools import find_packages, setup
@@ -10,10 +8,6 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as readme:
     long_description = readme.read()
 
-extra = {}
-if sys.version_info >= (3, 4):
-    extra["use_2to3"] = False
-    extra["convert_2to3_doctests"] = ["README.md"]
 
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
@@ -42,8 +36,20 @@ TESTS_REQUIRE = [
     "uvloop>=0.14.0",
 ]
 
-# Allow you to run pip install .[test] to get test dependencies included
-EXTRAS_REQUIRE = {"test": TESTS_REQUIRE}
+DEV_REQUIRE = [
+    *TESTS_REQUIRE,
+    "isort>=5.13.0",
+    "ruff>=0.4.0",
+    "black>=24.0.0",
+    "mypy>=1.10.0",
+    "build>=1.0.0",
+    "twine>=5.0.0",
+]
+
+EXTRAS_REQUIRE = {
+    "test": TESTS_REQUIRE,
+    "dev": DEV_REQUIRE,
+}
 
 setup(
     name="gmqtt",
@@ -53,9 +59,9 @@ setup(
     long_description_content_type="text/markdown",
     author=gmqtt.__author__,
     author_email=gmqtt.__email__,
-    license='MIT',
+    license="MIT",
     url="https://github.com/wialon/gmqtt",
-    packages=find_packages(exclude=['examples', 'tests']),
+    packages=find_packages(exclude=["examples", "tests"]),
     download_url="https://github.com/wialon/gmqtt",
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
@@ -64,5 +70,5 @@ setup(
     install_requires=[],
     tests_require=TESTS_REQUIRE,
     extras_require=EXTRAS_REQUIRE,
-    python_requires='>=3.5',
+    python_requires=">=3.5",
 )

--- a/tests/test_connack.py
+++ b/tests/test_connack.py
@@ -1,0 +1,328 @@
+"""
+Offline tests for _handle_connack_packet — covers four bugs:
+"""
+
+import asyncio
+import struct
+
+import pytest
+
+import gmqtt
+from gmqtt.mqtt.constants import MQTTv50, MQTTv311
+
+
+# ---------------------------------------------------------------------------
+# Packet-building helpers
+# ---------------------------------------------------------------------------
+
+def _pack_vbi(value: int) -> bytes:
+    """Minimal MQTT variable-byte integer encoder."""
+    result = bytearray()
+    while True:
+        value, b = divmod(value, 128)
+        if value > 0:
+            b |= 0x80
+        result.append(b)
+        if value == 0:
+            break
+    return bytes(result)
+
+
+def _build_connack_v5(
+    session_present: int, reason_code: int, props: bytes = b""
+) -> bytes:
+    """Return the packet bytes fed to _handle_connack_packet (MQTT v5 layout)."""
+    return struct.pack("!BB", session_present, reason_code) + _pack_vbi(len(props)) + props
+
+
+def _receive_maximum_prop(value: int) -> bytes:
+    """MQTT v5 Receive Maximum property (id=33 / 0x21, uint16)."""
+    return struct.pack("!BH", 33, value)
+
+
+# ---------------------------------------------------------------------------
+# Handler factory
+# ---------------------------------------------------------------------------
+
+class _FakeConnection:
+    """Minimal stand-in for MQTTConnection so _update_keepalive_if_needed works."""
+    keepalive = 60
+
+
+def _make_handler():
+    """Build an offline Client whose CONNACK callbacks are replaced by list-appending stubs.
+
+    Returns (client, handler, resend_calls, clear_calls, reconnect_calls).
+    """
+    client = gmqtt.Client("test-connack")
+    handler = client._package_handler
+    handler._connection = _FakeConnection()
+
+    resend_calls: list = []
+    clear_calls: list = []
+    reconnect_calls: list = []
+
+    async def fake_resend():
+        resend_calls.append("resend")
+
+    async def fake_clear():
+        clear_calls.append("clear")
+
+    async def fake_reconnect(delay=False):
+        reconnect_calls.append(delay)
+
+    async def fake_disconnect():
+        pass
+
+    handler._resend_qos_callback = fake_resend
+    handler._clear_qos_callback = fake_clear
+    handler._reconnect_callback = fake_reconnect
+    handler._disconnect_callback = fake_disconnect
+
+    return client, handler, resend_calls, clear_calls, reconnect_calls
+
+
+# ---------------------------------------------------------------------------
+# _connack_received must NOT be set on the v5→v3.1.1 downgrade path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_connected_not_set_on_protocol_downgrade():
+    """CONNACK result=1 (Unacceptable Protocol Version) while running
+    MQTT v5 triggers the v3.1.1 downgrade.  _connack_received must NOT be set
+    at this point — Client.connect() must keep waiting for the successful
+    CONNACK that will arrive after the reconnect with v3.1.1."""
+    _, handler, _, _, _ = _make_handler()
+    assert handler._connection_state.protocol_version == MQTTv50
+
+    packet = _build_connack_v5(session_present=0, reason_code=1)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert not handler._connack_received.is_set(), (
+        "_connack_received must not be set during the v5→v3.1.1 downgrade — "
+        "connect() should keep waiting for the next CONNACK."
+    )
+    assert handler._connection_state.protocol_version == MQTTv311, (
+        "Protocol version must be downgraded to v3.1.1 after result=1."
+    )
+
+
+@pytest.mark.asyncio
+async def test_connected_set_on_non_retriable_failure():
+    """A permanent CONNACK failure (e.g. 135 Not Authorized) must set
+    _connack_received so that an awaiting Client.connect() can unblock and propagate
+    the error via propagate_error()."""
+    _, handler, _, _, _ = _make_handler()
+
+    packet = _build_connack_v5(session_present=0, reason_code=135)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert handler._connack_received.is_set(), (
+        "_connack_received must be set on a permanent refusal so connect() can unblock "
+        "and surface the error."
+    )
+    assert handler._error is not None, "_error must be set on a refused CONNACK."
+
+
+# ---------------------------------------------------------------------------
+# session callbacks must not fire on a refused CONNACK
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_qos_callbacks_not_called_on_refused_connack():
+    """On result != 0 neither _resend_qos_callback nor _clear_qos_callback
+    must be scheduled."""
+    _, handler, resend_calls, clear_calls, _ = _make_handler()
+
+    packet = _build_connack_v5(session_present=0, reason_code=135)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert resend_calls == [], "resend_qos_callback must not run on a refused CONNACK"
+    assert clear_calls == [], "clear_qos_callback must not run on a refused CONNACK"
+
+
+@pytest.mark.asyncio
+async def test_qos_callbacks_not_called_on_downgrade():
+    """Same guarantee for the v5→v3.1.1 downgrade result code."""
+    _, handler, resend_calls, clear_calls, _ = _make_handler()
+
+    packet = _build_connack_v5(session_present=0, reason_code=1)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert resend_calls == [], "resend_qos_callback must not run during protocol downgrade"
+    assert clear_calls == [], "clear_qos_callback must not run during protocol downgrade"
+
+
+@pytest.mark.asyncio
+async def test_resend_called_on_success_with_session():
+    """On successful CONNACK with session_present=1, only
+    _resend_qos_callback must be scheduled."""
+    _, handler, resend_calls, clear_calls, _ = _make_handler()
+
+    packet = _build_connack_v5(session_present=1, reason_code=0)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert resend_calls == ["resend"], (
+        "_resend_qos_callback must fire on success with session_present=1"
+    )
+    assert clear_calls == [], (
+        "_clear_qos_callback must NOT fire when session_present=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_called_on_success_without_session():
+    """On successful CONNACK with session_present=0, only
+    _clear_qos_callback must be scheduled."""
+    _, handler, resend_calls, clear_calls, _ = _make_handler()
+
+    packet = _build_connack_v5(session_present=0, reason_code=0)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert resend_calls == [], (
+        "_resend_qos_callback must NOT fire when session_present=0"
+    )
+    assert clear_calls == ["clear"], (
+        "_clear_qos_callback must fire on success with session_present=0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# receive_maximum from CONNACK must update id_generator._max
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_receive_maximum_updates_id_generator():
+    """A successful CONNACK carrying receive_maximum=20 must cap
+    id_generator._max to 20."""
+    _, handler, _, _, _ = _make_handler()
+    assert handler.id_generator._max != 20  # sanity: default is much larger
+
+    props = _receive_maximum_prop(20)
+    packet = _build_connack_v5(session_present=0, reason_code=0, props=props)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert handler.id_generator._max == 20, (
+        f"id_generator._max must be updated to broker's receive_maximum=20; "
+        f"got {handler.id_generator._max}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_receive_maximum_not_applied_on_failed_connack():
+    """receive_maximum in a refused CONNACK packet must NOT change
+    id_generator._max (properties live after result, which is non-zero)."""
+    _, handler, _, _, _ = _make_handler()
+    original_max = handler.id_generator._max
+
+    # Build a refused CONNACK that still has properties bytes (edge case)
+    props = _receive_maximum_prop(10)
+    packet = _build_connack_v5(session_present=0, reason_code=135, props=props)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert handler.id_generator._max == original_max, (
+        f"id_generator._max must not change on a refused CONNACK; "
+        f"expected {original_max}, got {handler.id_generator._max}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_receive_maximum_keeps_default():
+    """A CONNACK with no receive_maximum property must leave
+    id_generator._max unchanged (65535 default)."""
+    _, handler, _, _, _ = _make_handler()
+    default_max = handler.id_generator._max
+
+    packet = _build_connack_v5(session_present=0, reason_code=0)
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert handler.id_generator._max == default_max, (
+        "id_generator._max must not change when receive_maximum is absent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRASH — malformed properties must not set _connack_properties to None
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_crash_malformed_properties_does_not_assign_none():
+    """CRASH: A successful-looking CONNACK with an invalid property id must
+    not crash and must not leave _connack_properties as None (which would
+    cause AttributeError on any subsequent .get() call)."""
+    _, handler, _, _, _ = _make_handler()
+
+    # 0xFF is not a valid MQTT v5 property id.
+    bad_prop = struct.pack("!B", 0xFF)
+    props_bytes = _pack_vbi(len(bad_prop)) + bad_prop
+    packet = struct.pack("!BB", 0, 0) + props_bytes  # session_present=0, result=0
+
+    handler._handle_connack_packet(0x20, packet)  # must not raise
+    await asyncio.sleep(0)
+
+    assert handler._connack_properties is not None, (
+        "_connack_properties must never be set to None; "
+        "a malformed properties block should be rejected cleanly."
+    )
+    # The error should be surfaced and a disconnect triggered.
+    assert handler._error is not None, (
+        "_error must be set when CONNACK properties cannot be parsed."
+    )
+
+
+@pytest.mark.asyncio
+async def test_crash_malformed_properties_connected_still_set():
+    """CRASH: Even when CONNACK properties are malformed, _connack_received must be
+    set so that Client.connect() can unblock and propagate the error."""
+    _, handler, _, _, _ = _make_handler()
+
+    bad_prop = struct.pack("!B", 0xFF)
+    props_bytes = _pack_vbi(len(bad_prop)) + bad_prop
+    packet = struct.pack("!BB", 0, 0) + props_bytes
+
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert handler._connack_received.is_set(), (
+        "_connack_received must be set even on malformed properties so connect() "
+        "can surface the error."
+    )
+
+
+@pytest.mark.asyncio
+async def test_crash_malformed_properties_fires_on_disconnect():
+    """CRASH: When CONNACK properties are malformed the on_disconnect callback
+    must fire so the application knows the connection was terminated and why."""
+    _, handler, _, _, _ = _make_handler()
+
+    disconnect_calls: list = []
+    handler.on_disconnect = lambda exc: disconnect_calls.append(exc)
+
+    bad_prop = struct.pack("!B", 0xFF)
+    props_bytes = _pack_vbi(len(bad_prop)) + bad_prop
+    packet = struct.pack("!BB", 0, 0) + props_bytes
+
+    handler._handle_connack_packet(0x20, packet)
+    await asyncio.sleep(0)
+
+    assert len(disconnect_calls) == 1, (
+        "on_disconnect must be called once when CONNACK properties are malformed"
+    )
+    assert isinstance(disconnect_calls[0], Exception), (
+        "on_disconnect should receive the MQTTConnectError as the second argument"
+    )
+
+

--- a/tests/test_connack.py
+++ b/tests/test_connack.py
@@ -65,7 +65,7 @@ def _make_handler():
     async def fake_resend():
         resend_calls.append("resend")
 
-    async def fake_clear():
+    def fake_clear():
         clear_calls.append("clear")
 
     async def fake_reconnect(delay=False):

--- a/tests/test_mid_pool.py
+++ b/tests/test_mid_pool.py
@@ -1,0 +1,171 @@
+import struct
+
+import gmqtt
+from gmqtt.mqtt.utils import IdGenerator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _id_gen(client: gmqtt.Client) -> IdGenerator:
+    """Convenience accessor: the client's outbound packet-id allocator."""
+    return client._package_handler.id_generator
+
+
+def _make_offline_client(name: str) -> gmqtt.Client:
+    """Construct a Client whose handler can run _handle_publish_packet without
+    a real connection.  _send_command_with_mid is stubbed so PUBACK/PUBREC
+    sends become no-ops."""
+    client = gmqtt.Client(name)
+    client._package_handler.on_message = lambda *args, **kwargs: None
+    client._package_handler._send_command_with_mid = lambda *args, **kwargs: None
+    return client
+
+
+def _build_v5_publish(topic: bytes, mid: int, payload: bytes, qos: int = 1):
+    """Build an MQTT v5 PUBLISH packet's fixed-header byte and variable part.
+
+    Returns (cmd_byte, raw_packet_after_fixed_header_byte_and_remaining_length).
+    The caller passes these straight into MqttPackageHandler._handle_publish_packet.
+    """
+    raw = struct.pack("!H", len(topic)) + topic
+    if qos > 0:
+        raw += struct.pack("!H", mid)
+    raw += b"\x00"  # property-length VBI = 0 (no properties)
+    raw += payload
+    cmd = 0x30 | (qos << 1)  # PUBLISH command | qos bits
+    return cmd, raw
+
+
+# ---------------------------------------------------------------------------
+# IdGenerator must not be a process-wide singleton
+# ---------------------------------------------------------------------------
+def test_idgenerator_instances_are_independent():
+    """Two IdGenerator() calls must return distinct objects."""
+    a = IdGenerator()
+    b = IdGenerator()
+    assert a is not b, (
+        "IdGenerator is a Singleton — every gmqtt.Client in the process "
+        "shares one 16-bit packet-id pool."
+    )
+
+
+def test_two_clients_have_independent_id_generators():
+    """Each Client must own its own IdGenerator instance (via its handler)."""
+    c1 = gmqtt.Client("client-1")
+    c2 = gmqtt.Client("client-2")
+    assert _id_gen(c1) is not _id_gen(c2), (
+        "Clients share an IdGenerator across instances."
+    )
+
+
+def test_one_client_id_allocation_does_not_leak_into_another():
+    """An allocation on client 1 must not change client 2's internal state,
+    and both clients must independently start their allocation sequence at 1."""
+    c1 = gmqtt.Client("client-3")
+    c2 = gmqtt.Client("client-4")
+
+    mid1 = _id_gen(c1).next_id()
+
+    assert _id_gen(c2)._used_ids == set(), (
+        f"Client 2's pool already saw client 1's allocation: "
+        f"{_id_gen(c2)._used_ids}."
+    )
+    assert _id_gen(c2)._last_used_id == 0
+
+    mid2 = _id_gen(c2).next_id()
+
+    assert mid1 == 1
+    assert mid2 == 1, (
+        f"Client 2 returned mid {mid2}; expected 1 from a fresh independent pool."
+    )
+
+
+def test_new_client_starts_with_empty_used_ids():
+    """A freshly constructed Client must not inherit used_ids from any
+    previously constructed Client."""
+    c1 = gmqtt.Client("client-5")
+    for _ in range(5):
+        _id_gen(c1).next_id()
+
+    c2 = gmqtt.Client("client-6")
+    assert _id_gen(c2)._used_ids == set(), (
+        f"New Client started with non-empty used_ids: "
+        f"{_id_gen(c2)._used_ids}."
+    )
+    assert _id_gen(c2)._last_used_id == 0
+
+
+# ---------------------------------------------------------------------------
+# Inbound PUBLISH must not feed broker mids into the outbound id pool
+# ---------------------------------------------------------------------------
+def test_inbound_qos1_publish_must_not_free_outbound_mid():
+    """Handling an inbound QoS 1 PUBLISH must NOT remove an outbound mid
+    from our id generator's used-id set."""
+    client = _make_offline_client("client-qos1")
+    gen = _id_gen(client)
+
+    OUTBOUND_MID = 42
+    gen._used_ids.add(OUTBOUND_MID)
+    gen._last_used_id = OUTBOUND_MID
+    assert OUTBOUND_MID in gen._used_ids
+
+    cmd, raw = _build_v5_publish(
+        topic=b"TEST/from-broker",
+        mid=OUTBOUND_MID,
+        payload=b"broker payload",
+        qos=1,
+    )
+    client._package_handler._handle_publish_packet(cmd, raw)
+
+    assert OUTBOUND_MID in gen._used_ids, (
+        "Handling an inbound PUBLISH freed an outbound mid from the pool."
+    )
+
+
+def test_inbound_qos2_publish_must_not_free_outbound_mid():
+    """Same as above but for inbound QoS 2."""
+    client = _make_offline_client("client-qos2")
+    gen = _id_gen(client)
+
+    OUTBOUND_MID = 1234
+    gen._used_ids.add(OUTBOUND_MID)
+    gen._last_used_id = OUTBOUND_MID
+
+    cmd, raw = _build_v5_publish(
+        topic=b"TEST/qos2",
+        mid=OUTBOUND_MID,
+        payload=b"qos2 payload",
+        qos=2,
+    )
+    client._package_handler._handle_publish_packet(cmd, raw)
+
+    assert OUTBOUND_MID in gen._used_ids, (
+        "Handling an inbound QoS 2 PUBLISH freed an outbound mid from the pool."
+    )
+
+
+def test_inbound_publish_does_not_cause_outbound_mid_collision():
+    """Practical consequence: after an inbound PUBLISH whose mid matches
+    one of our inflight outbound mids, next_id() must NOT hand the same mid
+    out to a new outbound publish."""
+    client = _make_offline_client("client-collision")
+    gen = _id_gen(client)
+
+    OUTBOUND_MID = 7
+    gen._used_ids.add(OUTBOUND_MID)
+    gen._last_used_id = OUTBOUND_MID - 1
+
+    cmd, raw = _build_v5_publish(
+        topic=b"TEST/collision",
+        mid=OUTBOUND_MID,
+        payload=b"x",
+        qos=1,
+    )
+    client._package_handler._handle_publish_packet(cmd, raw)
+
+    new_mid = gen.next_id()
+    assert new_mid != OUTBOUND_MID, (
+        f"next_id() returned mid={new_mid} which is still inflight on an "
+        f"outbound publish — the inbound PUBLISH handler corrupted the pool."
+    )

--- a/tests/test_mqtt5.py
+++ b/tests/test_mqtt5.py
@@ -290,7 +290,7 @@ async def test_redelivery_on_reconnect(init_clients):
 
     disconnect_client = gmqtt.Client(PREFIX + 'myclientid3', optimistic_acknowledgement=False,
                                      clean_session=False, session_expiry_interval=99999)
-    disconnect_client.set_config({'reconnect_retries': 0})
+    # disconnect_client.set_config({'reconnect_retries': 0})
     disconnect_client.on_message = on_message
     disconnect_client.set_auth_credentials(username)
 
@@ -328,7 +328,7 @@ async def xtest_async_on_message(init_clients):
 
     disconnect_client = gmqtt.Client(PREFIX + 'myclientid3', optimistic_acknowledgement=False,
                                      clean_session=False, session_expiry_interval=99999)
-    disconnect_client.set_config({'reconnect_retries': 0})
+    # disconnect_client.set_config({'reconnect_retries': 0})
     disconnect_client.on_message = on_message
     disconnect_client.set_auth_credentials(username)
 

--- a/tests/test_session_expiry_interval.py
+++ b/tests/test_session_expiry_interval.py
@@ -1,0 +1,147 @@
+"""Offline coverage for the MQTT 5.0 Session Expiry Interval (§3.1.2.11.2).
+
+The property is identifier 17 / Four Byte Integer.  It must be:
+  * accepted on `Client(...)` and serialised into the CONNECT properties.
+  * accepted on `client.disconnect(...)` and serialised into DISCONNECT.
+  * validated against the 0..0xFFFFFFFF range.
+  * readable back via `client.session_expiry_interval` (server CONNACK value
+    wins over the client's request per §3.2.2.3.2).
+"""
+import struct
+
+import pytest
+
+import gmqtt
+from gmqtt.mqtt.constants import MQTTv50, MQTTv311
+from gmqtt.mqtt.package import DisconnectPacket, LoginPackageFactor
+from gmqtt.mqtt.property import PROPERTIES_BY_ID, PROPERTIES_BY_NAME
+
+
+class _StubProto:
+    """Minimal stand-in for MQTTProtocol used by package builders."""
+    proto_name = b"MQTT"
+
+    def __init__(self, ver=MQTTv50):
+        self.proto_ver = ver
+
+
+# ---------------------------------------------------------------------------
+# Property table sanity
+# ---------------------------------------------------------------------------
+def test_session_expiry_interval_property_definition():
+    prop = PROPERTIES_BY_NAME["session_expiry_interval"]
+    assert prop.id == 17
+    assert prop.bytes_struct == "!L"
+    assert PROPERTIES_BY_ID[17] is prop
+    # §3.1.2.11.2 (CONNECT), §3.2.2.3.2 (CONNACK), §3.14.2.2.2 (DISCONNECT)
+    assert set(prop.allowed_packages) == {"CONNECT", "CONNACK", "DISCONNECT"}
+
+
+# ---------------------------------------------------------------------------
+# Construction-time validation
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("value", [-1, 0x1_0000_0000, 0x1_0000_0001])
+def test_session_expiry_interval_out_of_range_rejected(value):
+    with pytest.raises(ValueError):
+        gmqtt.Client("c", session_expiry_interval=value)
+
+
+@pytest.mark.parametrize("value", ["60", 1.5, True])
+def test_session_expiry_interval_wrong_type_rejected(value):
+    with pytest.raises(TypeError):
+        gmqtt.Client("c", session_expiry_interval=value)
+
+
+@pytest.mark.parametrize("value", [0, 1, 60, 0xFFFFFFFE, 0xFFFFFFFF])
+def test_session_expiry_interval_in_range_accepted(value):
+    c = gmqtt.Client("c", session_expiry_interval=value)
+    assert c._connect_properties["session_expiry_interval"] == value
+
+
+def test_session_expiry_interval_absent_defaults_to_zero():
+    c = gmqtt.Client("c")
+    assert c.session_expiry_interval == 0
+
+
+# ---------------------------------------------------------------------------
+# Encoding on the wire
+# ---------------------------------------------------------------------------
+def _find_property_value(packet: bytes, prop_id: int, fmt: str):
+    """Search for property identifier byte followed by its packed value
+    anywhere in the packet.  Good enough for offline assertion."""
+    size = struct.calcsize(fmt)
+    needle_id = bytes([prop_id])
+    for i in range(len(packet) - size):
+        if packet[i:i + 1] == needle_id:
+            try:
+                return struct.unpack(fmt, packet[i + 1:i + 1 + size])[0]
+            except struct.error:
+                continue
+    return None
+
+
+def test_session_expiry_interval_serialised_in_connect_v5():
+    packet = LoginPackageFactor.build_package(
+        client_id="cid",
+        username=None,
+        password=None,
+        clean_session=True,
+        keepalive=60,
+        protocol=_StubProto(MQTTv50),
+        session_expiry_interval=600,
+    )
+    assert _find_property_value(bytes(packet), 17, "!L") == 600
+
+
+def test_session_expiry_interval_max_value_round_trips_in_connect():
+    packet = LoginPackageFactor.build_package(
+        client_id="cid",
+        username=None,
+        password=None,
+        clean_session=True,
+        keepalive=60,
+        protocol=_StubProto(MQTTv50),
+        session_expiry_interval=0xFFFFFFFF,
+    )
+    assert _find_property_value(bytes(packet), 17, "!L") == 0xFFFFFFFF
+
+
+def test_session_expiry_interval_omitted_when_v311():
+    # MQTT 3.1.1 has no properties; the kwarg must be silently dropped, not raise.
+    packet = LoginPackageFactor.build_package(
+        client_id="cid",
+        username=None,
+        password=None,
+        clean_session=True,
+        keepalive=60,
+        protocol=_StubProto(MQTTv311),
+        session_expiry_interval=600,
+    )
+    # No property bytes at all in v3.1.1.
+    assert _find_property_value(bytes(packet), 17, "!L") is None
+
+
+def test_session_expiry_interval_serialised_in_disconnect_v5():
+    packet = DisconnectPacket.build_package(
+        protocol=_StubProto(MQTTv50),
+        reason_code=0,
+        session_expiry_interval=0,
+    )
+    assert _find_property_value(bytes(packet), 17, "!L") == 0
+
+
+# ---------------------------------------------------------------------------
+# Server CONNACK override (§3.2.2.3.2)
+# ---------------------------------------------------------------------------
+def test_session_expiry_interval_property_uses_server_value_when_present():
+    c = gmqtt.Client("c", session_expiry_interval=600)
+    # Simulate broker-assigned override; _parse_properties returns a list,
+    # so the value is wrapped in a list matching what a real CONNACK produces.
+    # _parse_properties stores values as lists (defaultdict(list) + .append).
+    c._package_handler._connack_properties["session_expiry_interval"] = [120]
+    assert c.session_expiry_interval == 120
+
+
+def test_session_expiry_interval_property_falls_back_to_request():
+    c = gmqtt.Client("c", session_expiry_interval=600)
+    assert c.session_expiry_interval == 600

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,7 @@ class Callbacks:
         client.on_subscribe = self.on_subscribe
 
 
-async def clean_retained(host, port, username, password=None, prefix=None):
+async def clean_retained(host, port, username, password=None, prefix=None, wait=2):
     def on_message(client, topic, payload, qos, properties):
         curclient.publish(topic, b"", qos=0, retain=True)
 
@@ -60,7 +60,7 @@ async def clean_retained(host, port, username, password=None, prefix=None):
     await curclient.connect(host=host, port=port)
     topic = '#' if not prefix else prefix + '#'
     curclient.subscribe(topic)
-    await asyncio.sleep(10)  # wait for all retained messages to arrive
+    await asyncio.sleep(wait)  # wait for retained messages to arrive; tune via `wait=` if there are many topics
     await curclient.disconnect()
     time.sleep(.1)
 


### PR DESCRIPTION
Fixes:

- IdGenerator Singleton removed; per-Client allocator wired through functools.partial(MQTTProtocol, id_generator=...) in MQTTConnection.create_connection. (Note: the old "set_handler" wiring mentioned in the previous file is gone — id_generator is now passed via the protocol factory itself.)
- free_id(mid) calls removed from both inbound PUBLISH paths.
- MQTTProtocol.proto_ver is now a property over per-Client ConnectionState.protocol_version.
- CONNACK handling fixed: Clientcould block on reconnect
- Malformed CONNACK properties does not mutate other entities
- receive_maximum now considered from CONNACK properties and used in id_generator._max at connection time.
- HeapPersistentStorage replaced with OrderedDict-backed PersistentStorage in storage.py.
- use_2to3 block deleted from setup.py.
- PersistentStorage.clear() now notifies all wait_empty waiters.
- shared ConnectionState dataclass in utils.py is now the layout source of truth.
- Logging improved in Package Handler and Client